### PR TITLE
HCG-33: Ability to track changes in hostname IPs

### DIFF
--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -12,6 +12,7 @@ import (
 
 	kuadrantv1 "github.com/kuadrant/kcp-glbc/pkg/client/kuadrant/clientset/versioned"
 	"github.com/kuadrant/kcp-glbc/pkg/client/kuadrant/informers/externalversions"
+	"github.com/kuadrant/kcp-glbc/pkg/net"
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler/dns"
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler/ingress"
 )
@@ -28,6 +29,7 @@ var domain = flag.String("domain", "hcpapps.net", "The domain to use to expose i
 var dnsProvider = flag.String("dns-provider", "aws", "The DNS provider being used [aws, fake]")
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Parse()
 
 	var overrides clientcmd.ConfigOverrides
@@ -61,6 +63,12 @@ func main() {
 		DnsRecordClient:       dnsRecordClient,
 		SharedInformerFactory: kubeInformerFactory,
 		Domain:                domain,
+		HostResolver:          net.NewDefaultHostResolver(),
+		// For testing. TODO: Make configurable through flags/env variable
+		// HostResolver: &net.ConfigMapHostResolver{
+		// 	Name:      "hosts",
+		// 	Namespace: "default",
+		// },
 	}
 	ingressController := ingress.NewController(controllerConfig)
 

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,13 @@ require (
 	github.com/aws/aws-sdk-go v1.38.49
 	github.com/google/go-cmp v0.5.6
 	github.com/imdario/mergo v0.3.9 // indirect
+	github.com/miekg/dns v1.1.17
 	github.com/rs/xid v1.3.0
-	golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff // indirect
 	google.golang.org/grpc v1.42.0 // indirect
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.21.4
-	k8s.io/code-generator v0.21.4 // indirect
 	k8s.io/klog/v2 v2.30.0
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 )

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,6 @@ github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20220210121228
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:0xHdTqpGRk94GXkfb/BusWREH3MLNiN7rhjiDu+W0IQ=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20220210121228-50b2affb6ca1 h1:86ChgGnyvbDPZYqx2jPbJzK31B7OkU3IWZ+PotMzubU=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:8EW66ZxqXWRv5gHB91chqPslhH0CYNvLWLOCEIj8gHE=
-github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20220210121228-50b2affb6ca1 h1:gUcWHu0hEP7Hv+uoODJ5sBQPpPRRrHLRYwpQhBW9QIs=
-github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:3Oz9SHvALoA5bm6QReTojYUzTDd957L3aMY0/DkPzBY=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20220210121228-50b2affb6ca1 h1:uVO5bbKcYrWzEEkBIYxJgIFaKKeksf4voz8a0NYlIR0=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:4IWNaSBE0Z02qopZW9+g2IbDAqFG+1alRB847qhaIco=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -355,6 +353,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.17 h1:BhJxdA7bH51vKFZSY8Sn9pR7++LREvg0eYFzHA452ew=
+github.com/miekg/dns v1.1.17/go.mod h1:WgzbA6oji13JREwiNsRDNfl7jYdPnmz+VEuLrA+/48M=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -557,6 +557,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -597,7 +598,6 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -772,6 +772,7 @@ golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -973,7 +974,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/pkg/net/hostresolv.go
+++ b/pkg/net/hostresolv.go
@@ -1,0 +1,130 @@
+package net
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	gonet "net"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type HostResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]HostAddress, error)
+}
+
+type HostAddress struct {
+	Host string
+	IP   gonet.IP
+	TTL  time.Duration
+}
+
+// ConfigMapHostResolver is a HostResolver that looks up the IP address of
+// a host from a ConfigMap. Used for testing purposes
+type ConfigMapHostResolver struct {
+	Client kubernetes.Interface
+
+	Name, Namespace string
+}
+
+var _ HostResolver = &ConfigMapHostResolver{}
+
+func (r *ConfigMapHostResolver) LookupIPAddr(ctx context.Context, host string) ([]HostAddress, error) {
+	configMap, err := r.Client.CoreV1().ConfigMaps(r.Namespace).Get(ctx, r.Name, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	ipsValue, ok := configMap.Data[host]
+	if !ok {
+		return nil, &gonet.DNSError{Err: fmt.Sprintf("host not found in ConfigMap %s/%s", r.Name, r.Namespace)}
+	}
+
+	ips := []struct {
+		IP  string
+		TTL int
+	}{}
+	if err := json.Unmarshal([]byte(ipsValue), &ips); err != nil {
+		return nil, err
+	}
+
+	result := make([]HostAddress, len(ips))
+	for i, ip := range ips {
+		result[i] = HostAddress{
+			Host: host,
+			IP:   gonet.ParseIP(ip.IP),
+			TTL:  time.Duration(ip.TTL) * time.Second,
+		}
+	}
+
+	return result, nil
+}
+
+type DefaultHostResolver struct {
+	Client dns.Client
+}
+
+func NewDefaultHostResolver() *DefaultHostResolver {
+	return &DefaultHostResolver{
+		Client: dns.Client{},
+	}
+}
+
+func (hr *DefaultHostResolver) LookupIPAddr(ctx context.Context, host string) ([]HostAddress, error) {
+	cfg, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, server := range cfg.Servers {
+		m := dns.Msg{}
+		m.SetQuestion(fmt.Sprintf("%s.", host), dns.TypeA)
+
+		r, _, err := hr.Client.ExchangeContext(ctx, &m, fmt.Sprintf("%s:53", server))
+		if err != nil {
+			return nil, err
+		}
+
+		if len(r.Answer) == 0 {
+			continue
+		}
+
+		results := make([]HostAddress, 0, len(r.Answer))
+		for _, answer := range r.Answer {
+			if a, ok := answer.(*dns.A); ok {
+				results = append(results, HostAddress{
+					Host: host,
+					IP:   a.A,
+					TTL:  time.Duration(a.Hdr.Ttl) * time.Second,
+				})
+			}
+		}
+
+		return results, nil
+	}
+
+	return nil, errors.New("no records found for host")
+}
+
+type SafeHostResolver struct {
+	HostResolver
+
+	mu sync.Mutex
+}
+
+func NewSafeHostResolver(inner HostResolver) *SafeHostResolver {
+	return &SafeHostResolver{
+		HostResolver: inner,
+	}
+}
+
+func (r *SafeHostResolver) LookupIPAddr(ctx context.Context, host string) ([]HostAddress, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.HostResolver.LookupIPAddr(ctx, host)
+}

--- a/pkg/net/watch.go
+++ b/pkg/net/watch.go
@@ -1,0 +1,143 @@
+package net
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// HostsWatcher keeps track of changes in host addresses in the background.
+// It associates a host with a key that is passed to the `OnChange` callback
+// whenever a change is detected
+type HostsWatcher struct {
+	Resolver      HostResolver
+	Records       []recordWatcher
+	OnChange      func(interface{})
+	WatchInterval func(ttl time.Duration) time.Duration
+}
+
+func NewHostsWatcher(resolver HostResolver, watchInterval func(ttl time.Duration) time.Duration) *HostsWatcher {
+	return &HostsWatcher{
+		Resolver:      resolver,
+		Records:       []recordWatcher{},
+		WatchInterval: watchInterval,
+	}
+}
+
+// StartWatching begins tracking changes in the addresses for host
+func (w *HostsWatcher) StartWatching(ctx context.Context, obj interface{}, host string) bool {
+	for _, recordWatcher := range w.Records {
+		if recordWatcher.Key == obj && recordWatcher.Host == host {
+			return false
+		}
+	}
+
+	recordWatcher := recordWatcher{
+		stopCh:        make(chan struct{}),
+		resolver:      w.Resolver,
+		Host:          host,
+		Key:           obj,
+		OnChange:      w.OnChange,
+		Records:       []HostAddress{},
+		WatchInterval: w.WatchInterval,
+	}
+	recordWatcher.Watch(ctx)
+
+	w.Records = append(w.Records, recordWatcher)
+
+	klog.V(3).Infof("Started watching %s with host %s", obj, host)
+	return true
+}
+
+// StopWatching stops tracking changes in the addresses associated to obj
+func (w *HostsWatcher) StopWatching(obj interface{}) {
+	records := []recordWatcher{}
+	for _, recordWatcher := range w.Records {
+		if recordWatcher.Key == obj {
+			recordWatcher.Stop()
+			continue
+		}
+
+		records = append(records, recordWatcher)
+	}
+
+	w.Records = records
+}
+
+type recordWatcher struct {
+	resolver HostResolver
+	stopCh   chan struct{}
+
+	Key           interface{}
+	OnChange      func(key interface{})
+	WatchInterval func(ttl time.Duration) time.Duration
+	Host          string
+	Records       []HostAddress
+}
+
+func DefaultInterval(ttl time.Duration) time.Duration {
+	return ttl / 2
+}
+
+func (w *recordWatcher) Watch(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-w.stopCh:
+				return
+			default:
+			}
+
+			newRecords, err := w.resolver.LookupIPAddr(ctx, w.Host)
+			if err != nil {
+				klog.Error(err)
+				continue
+			}
+
+			if updated := w.updateRecords(newRecords); updated {
+				klog.V(3).Infof("New records found for host %s. Updating", w.Host)
+				w.OnChange(w.Key)
+			}
+
+			ttl := w.Records[0].TTL
+			refreshInterval := w.WatchInterval(ttl)
+			time.Sleep(refreshInterval)
+			klog.V(4).Infof("Refreshing records for host %s with TTL %d. Refresh interval: %d", w.Host, int(ttl.Seconds()), int(refreshInterval.Seconds()))
+		}
+	}()
+}
+
+func (w *recordWatcher) updateRecords(newRecords []HostAddress) bool {
+	if len(w.Records) != len(newRecords) {
+		w.Records = newRecords
+		return true
+	}
+
+	updatedIPs := false
+	updatedTTLs := false
+
+	for i, newRecord := range newRecords {
+		if !w.Records[i].IP.Equal(newRecord.IP) {
+			updatedIPs = true
+			continue
+		}
+
+		if w.Records[i].TTL < newRecord.TTL {
+			updatedTTLs = true
+		}
+	}
+
+	if updatedIPs || updatedTTLs {
+		w.Records = newRecords
+	}
+
+	return updatedIPs
+}
+
+func (w *recordWatcher) Stop() {
+	klog.V(3).Infof("Stopping record watcher for %s/%s", w.Key, w.Host)
+	close(w.stopCh)
+}


### PR DESCRIPTION
## Description

> Link to JIRA: https://issues.redhat.com/browse/HCG-33

Add ability for the controller to keep track of the current host -> IP mappings and notify the Ingress reconciler if there's any changes. The reconciler will propagate the changes to the DNSRecord.

## Steps to verify

To verify locally, a [`ConfigMapHostResolver`](https://github.com/Kuadrant/kcp-glbc/pull/19/files#diff-7078f0862820391d59c2ad9da6fbce41aaebbcba849902bee0010bd219f2f329R47-R51) is available. Selecting that resolver:

1. Run KCP and the Ingress controller
2. Create a ConfigMap with the expected hosts. Example
    ```yaml
    apiVersion: v1
    data:
      3806265934.hcpapps.net: '[{"IP": "1.1.1.1","TTL":30}, {"IP": "12.12.12.12","TTL":30}]'
      my-hostname.hcpapps.net: '[{"IP":"2.2.2.2","TTL":60}]'
    kind: ConfigMap
    metadata:
      clusterName: admin
      creationTimestamp: "2022-02-24T16:02:22Z"
      name: hosts
      namespace: default
      resourceVersion: "248"
      uid: 4f1417af-1444-4468-a415-6eb370f3c6e5
    ```
3. Start the GLB controller and verify that the DNSRecords are created with the targets from the ConfigMap
4. Update the ConfigMap (add or remove IPs)
5. Verify that the DNSRecords are updated once the refresh interval passes
    * The log will print the following:
        ```
        I0224 16:29:37.242119  555277 dns_record.go:78] replacing DNS recordrecord{c8bqo075runrl0f6ji8g.hcpapps.net [1.1.1.1 12.12.12.12] A 60}dnszone{foo map[]}
        I0224 16:29:37.242189  555277 dns_record.go:86] replaced DNS record in zonerecord{c8bqo075runrl0f6ji8g.hcpapps.net [1.1.1.1 12.12.12.12] A 60}dnszone{foo map[]}
        ```