### PR TITLE
Hcg 44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ all: vendor build
 .PHONY: all
 
 SHELL := /bin/bash
-NUM_CLUSTERS:= 2
+NUM_CLUSTERS := 2
+KCP_BRANCH := release-prototype-2
 # go-get-tool will 'go get' any package $2 and install it to $1.
 # backing up and recovering the go.mod/go.sum as go install doesnt work
 # with project that use replacement directives, no time for a nicer solution.
@@ -35,7 +36,7 @@ kind:
 KCP = $(shell pwd)/bin/kcp
 kcp:
 	rm -rf ./tmp/kcp
-	git clone --depth=1 https://github.com/kcp-dev/kcp ./tmp/kcp
+	git clone --depth=1 --branch ${KCP_BRANCH} https://github.com/kcp-dev/kcp ./tmp/kcp
 	cd ./tmp/kcp && make
 	cp ./tmp/kcp/bin/cluster-controller $(shell pwd)/bin
 	cp ./tmp/kcp/bin/compat $(shell pwd)/bin

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ kind:
 
 # Not ideal, fix when possible.
 KCP = $(shell pwd)/bin/kcp
+INGRESS_CONTROLLER = $(shell pwd)/bin/ingress-controller
+
 kcp:
 	rm -rf ./tmp/kcp
 	git clone --depth=1 --branch ${KCP_BRANCH} https://github.com/kcp-dev/kcp ./tmp/kcp
@@ -47,6 +49,7 @@ kcp:
 	cp ./tmp/kcp/bin/shard-proxy $(shell pwd)/bin
 	cp ./tmp/kcp/bin/syncer $(shell pwd)/bin
 	cp ./tmp/kcp/bin/virtual-workspaces $(shell pwd)/bin
+	cp ./tmp/kcp/bin/ingress-controller $(shell pwd)/bin
 	rm -rf ./tmp/kcp
 
 .PHONY: local-setup

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -191,11 +191,9 @@ func (c *Controller) process(key string) error {
 
 	ctx := context.TODO()
 
-	rootName, isLeaf := getRootName(current)
+	_, isLeaf := getRootName(current)
 	if isLeaf {
-		err = c.reconcileLeaf(ctx, rootName, current)
-	} else {
-		err = c.reconcileRoot(ctx, current)
+		err = c.reconcileLeafDNS(ctx, current)
 	}
 	if err != nil {
 		return err

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -3,121 +3,45 @@ package ingress
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
-	"net"
-	"strings"
-
 	"github.com/rs/xid"
 	"k8s.io/apimachinery/pkg/util/json"
+	"net"
 
-	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 
 	v1 "github.com/kuadrant/kcp-ingress/pkg/apis/kuadrant/v1"
-	"github.com/kuadrant/kcp-ingress/pkg/envoy"
 )
 
 const (
-	clusterLabel = "kcp.dev/cluster"
-	ownedByLabel = "kcp.dev/owned-by"
-
 	hostGeneratedAnnotation = "kuadrant.dev/host.generated"
-
+	ownedByLabel            = "ingress.kcp.dev/owned-by-ingress"
 	manager                 = "kcp-ingress"
-	cascadeCleanupFinalizer = "kcp.dev/cascade-cleanup"
+	dnsCleanupFinalizer     = "ingress.kcp.dev/ingress-dns-cleanup"
 )
 
-func (c *Controller) reconcileRoot(ctx context.Context, ingress *networkingv1.Ingress) error {
+func (c *Controller) reconcileLeafDNS(ctx context.Context, ingress *networkingv1.Ingress) error {
 	// is deleting
 	if ingress.DeletionTimestamp != nil && !ingress.DeletionTimestamp.IsZero() {
-		klog.Infof("deleting root ingress '%v'", ingress.Name)
-		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, ingress.Name))
-		if err != nil {
-			return err
-		}
-		currentLeaves, err := c.lister.List(sel)
-		klog.Infof("found %v leaf ingresses", len(currentLeaves))
-		for _, leaf := range currentLeaves {
-			err = c.client.NetworkingV1().Ingresses(leaf.Namespace).Delete(ctx, leaf.Name, metav1.DeleteOptions{})
-			if err != nil {
-				return err
-			}
-		}
 		// delete DNSRecord
-		err = c.dnsRecordClient.DNSRecords(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{})
+		err := c.dnsRecordClient.DNSRecords(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
-		// all leaves removed, remove finalizer
-		klog.Infof("'%v' ingress leaves cleaned up - removing finalizer", ingress.Name)
-		removeFinalizer(ingress, cascadeCleanupFinalizer)
-
+		removeFinalizer(ingress, dnsCleanupFinalizer)
 		return nil
 	}
 
-	AddFinalizer(ingress, cascadeCleanupFinalizer)
+	AddFinalizer(ingress, dnsCleanupFinalizer)
 	if ingress.Annotations == nil || ingress.Annotations[hostGeneratedAnnotation] == "" {
 		// Let's assign it a global hostname if any
 		generatedHost := fmt.Sprintf("%s.%s", xid.New(), *c.domain)
 		patch := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, hostGeneratedAnnotation, generatedHost)
 		if err := c.patchIngress(ctx, ingress, []byte(patch)); err != nil {
 			return err
-		}
-	}
-
-	// Get the current leaves
-	sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, ingress.Name))
-	if err != nil {
-		return err
-	}
-	currentLeaves, err := c.lister.List(sel)
-	if err != nil {
-		return err
-	}
-
-	// Generate the desired leaves
-	desiredLeaves, err := c.desiredLeaves(ctx, ingress)
-	if err != nil {
-		return err
-	}
-
-	// Delete the leaves that are not desired anymore
-	for _, leftover := range findNonDesiredLeaves(currentLeaves, desiredLeaves) {
-		// The clean-up, i.e., removal of the DNS records, will be done in the next reconciliation cycle
-		klog.Infof("Deleting non desired leaf %q", leftover.Name)
-		if err := c.client.NetworkingV1().Ingresses(leftover.Namespace).Delete(ctx, leftover.Name, metav1.DeleteOptions{}); err != nil {
-			return err
-		}
-	}
-
-	// TODO(jmprusi): ugly. fix. use indexer, etc.
-	// Create and/or update the desired leaves
-	for _, leaf := range desiredLeaves {
-		if _, err := c.client.NetworkingV1().Ingresses(leaf.Namespace).Create(ctx, leaf, metav1.CreateOptions{}); err != nil {
-			if errors.IsAlreadyExists(err) {
-				existingLeaf, err := c.client.NetworkingV1().Ingresses(leaf.Namespace).Get(ctx, leaf.Name, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-
-				// Set the resourceVersion and UID to update the desired leaf.
-				leaf.ResourceVersion = existingLeaf.ResourceVersion
-				leaf.UID = existingLeaf.UID
-
-				if _, err := c.client.NetworkingV1().Ingresses(leaf.Namespace).Update(ctx, leaf, metav1.UpdateOptions{}); err != nil {
-					return err
-				}
-			} else {
-				return err
-			}
 		}
 	}
 
@@ -147,80 +71,6 @@ func (c *Controller) reconcileRoot(ctx context.Context, ingress *networkingv1.In
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (c *Controller) reconcileLeaf(ctx context.Context, rootName string, ingress *networkingv1.Ingress) error {
-	// The leaf Ingress was updated, get others and aggregate status.
-	sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, rootName))
-	if err != nil {
-		return err
-	}
-	others, err := c.lister.List(sel)
-	if err != nil {
-		return err
-	}
-
-	// Get the rootIngress based on the labels.
-	var rootIngress *networkingv1.Ingress
-
-	rootIf, exists, err := c.indexer.Get(&v1beta1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   ingress.Namespace,
-			Name:        rootName,
-			ClusterName: ingress.GetClusterName(),
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		klog.Infof("deleting orphaned leaf ingress '%v' of nonexistant root ingress '%v'", ingress.Name, rootName)
-		return c.client.NetworkingV1().Ingresses(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{})
-	}
-
-	if ingress.DeletionTimestamp != nil && !ingress.DeletionTimestamp.IsZero() {
-		// The Ingress is being deleted. KCP doesn't currently cascade deletion to owned resources
-		removeFinalizer(ingress, cascadeCleanupFinalizer)
-	}
-
-	// Clean the current status, and then recreate if from the other leafs.
-	rootIngress = rootIf.(*networkingv1.Ingress).DeepCopy()
-	rootIngress.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{}
-	for _, o := range others {
-		// Should the root Ingress status be updated only once the DNS record is successfully created / updated?
-		rootIngress.Status.LoadBalancer.Ingress = append(rootIngress.Status.LoadBalancer.Ingress, o.Status.LoadBalancer.Ingress...)
-	}
-
-	// If the envoy control plane is enabled, we update the cache and generate and send to envoy a new snapshot.
-	if c.envoyXDS != nil {
-		c.cache.UpdateIngress(*rootIngress)
-		err = c.envoyXDS.SetSnapshot(envoy.NodeID, c.cache.ToEnvoySnapshot())
-		if err != nil {
-			return err
-		}
-
-		statusHost := generateStatusHost(c.domain, rootIngress)
-		// Now overwrite the Status of the rootIngress with our desired LB
-		rootIngress.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{
-			Hostname: statusHost,
-		}}
-	}
-
-	// Update the root Ingress status with our desired LB.
-	if _, err := c.client.NetworkingV1().Ingresses(rootIngress.Namespace).UpdateStatus(ctx, rootIngress, metav1.UpdateOptions{}); err != nil {
-		if errors.IsConflict(err) {
-			key, err := cache.MetaNamespaceKeyFunc(ingress)
-			if err != nil {
-				return err
-			}
-			c.queue.AddRateLimited(key)
-			return nil
-		}
-		return err
 	}
 
 	return nil
@@ -277,99 +127,6 @@ func getDNSRecord(hostname string, ingress *networkingv1.Ingress) (*v1.DNSRecord
 	return record, nil
 }
 
-func (c *Controller) desiredLeaves(ctx context.Context, root *networkingv1.Ingress) ([]*networkingv1.Ingress, error) {
-	// This will parse the ingresses and extract all the destination services,
-	// then create a new ingress leaf for each of them.
-	services, err := c.getServices(ctx, root)
-	if err != nil {
-		return nil, err
-	}
-
-	var clusters []string
-	for _, service := range services {
-		if service.Labels[clusterLabel] != "" {
-			clusters = append(clusters, service.Labels[clusterLabel])
-		} else {
-			klog.Infof("Skipping service %q because it is not assigned to any cluster", service.Name)
-		}
-
-		// Trigger reconciliation of the root ingress when this service changes.
-		c.tracker.add(root, service)
-	}
-
-	desiredLeaves := make([]*networkingv1.Ingress, 0, len(clusters))
-	for _, cl := range clusters {
-		vd := root.DeepCopy()
-		// TODO: munge cluster name
-		vd.Name = fmt.Sprintf("%s--%s", root.Name, cl)
-
-		vd.Labels = map[string]string{}
-		vd.Labels[clusterLabel] = cl
-		vd.Labels[ownedByLabel] = root.Name
-
-		// Cleanup finalizers
-		vd.Finalizers = []string{}
-		// Cleanup owner references
-		vd.OwnerReferences = []metav1.OwnerReference{}
-		vd.SetResourceVersion("")
-
-		if hostname, ok := root.Annotations[hostGeneratedAnnotation]; ok {
-			// Duplicate the existing rules for the global hostname
-			globalRules := make([]networkingv1.IngressRule, len(vd.Spec.Rules))
-			for i, rule := range vd.Spec.Rules {
-				r := rule.DeepCopy()
-				r.Host = hostname
-				globalRules[i] = *r
-			}
-			vd.Spec.Rules = append(vd.Spec.Rules, globalRules...)
-		}
-
-		desiredLeaves = append(desiredLeaves, vd)
-	}
-
-	return desiredLeaves, nil
-}
-
-func hashString(s string) string {
-	h := fnv.New32a()
-	h.Write([]byte(s))
-	return fmt.Sprint(h.Sum32())
-}
-
-func generateStatusHost(domain *string, ingress *networkingv1.Ingress) string {
-	// TODO(jmprusi): using "contains" is a bad idea as it could be abused by crafting a malicious hostname, but for a PoC it should be good enough?
-	allRulesAreDomain := true
-	for _, rule := range ingress.Spec.Rules {
-		if !strings.Contains(rule.Host, *domain) {
-			allRulesAreDomain = false
-			break
-		}
-	}
-
-	// TODO(jmprusi): Hardcoded to the first one...
-	if allRulesAreDomain {
-		return ingress.Spec.Rules[0].Host
-	}
-
-	return hashString(ingress.Name+ingress.Namespace+ingress.ClusterName) + "." + *domain
-}
-
-// getServices will parse the ingress object and return a list of the services.
-func (c *Controller) getServices(ctx context.Context, ingress *networkingv1.Ingress) ([]*corev1.Service, error) {
-	var services []*corev1.Service
-	for _, rule := range ingress.Spec.Rules {
-		for _, path := range rule.HTTP.Paths {
-			svc, err := c.client.CoreV1().Services(ingress.Namespace).Get(ctx, path.Backend.Service.Name, metav1.GetOptions{})
-			// TODO(jmprusi): If one of the services doesn't exist, we invalidate all the other ones.. review this.
-			if err != nil {
-				return nil, err
-			}
-			services = append(services, svc)
-		}
-	}
-	return services, nil
-}
-
 func (c *Controller) patchIngress(ctx context.Context, ingress *networkingv1.Ingress, data []byte) error {
 	i, err := c.client.NetworkingV1().Ingresses(ingress.Namespace).
 		Patch(ctx, ingress.Name, types.MergePatchType, data, metav1.PatchOptions{FieldManager: manager})
@@ -378,24 +135,6 @@ func (c *Controller) patchIngress(ctx context.Context, ingress *networkingv1.Ing
 	}
 	ingress = i
 	return nil
-}
-
-func findNonDesiredLeaves(current, desired []*networkingv1.Ingress) []*networkingv1.Ingress {
-	var missing []*networkingv1.Ingress
-
-	for _, c := range current {
-		found := false
-		for _, d := range desired {
-			if c.Name == d.Name {
-				found = true
-			}
-		}
-		if !found {
-			missing = append(missing, c)
-		}
-	}
-
-	return missing
 }
 
 func getRootName(ingress *networkingv1.Ingress) (rootName string, isLeaf bool) {


### PR DESCRIPTION
running make local-setup will now also start the ingress-controller - this will create leaf Ingress from a root ingress, however deleting the root ingress does not currently result in the leaf ingress being deleted - this feels like a bug in the ingress-controller.

kcp-glbc will now only use ingress for the reconciling of DNSRecords.

# verification
- stop any running local-setup and checkout this branch
- execute `make local-setup`
- `kubectl create namespace default`
- `kubectl create -f samples/echo-service-multi-cluster`
- Wait a minute or two, and all leaves and their DNSRecord CRs should be created
- if using route53 the changes should also be reflected there
- `kubectl delete -f samples/echo-service-multi-cluster`
- root ingress are deleted, but not leaf ingress - delete these leaf ingresses manually
- the DNSRecord CRs will then be cleaned up automatically
- the DNS records in route53 will also be cleaned up.