### PR TITLE
Allows to prevent custom hosts from being used

### DIFF
--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -34,7 +34,7 @@ var region = flag.String("region", "eu-central-1", "the region we should target 
 var kubecontext = flag.String("context", "", "Context to use in the Kubeconfig file, instead of the current context")
 
 var domain = flag.String("domain", "hcpapps.net", "The domain to use to expose ingresses")
-var customHosts = flag.Bool("custom-hosts", true, "Flag to enable hosts to be custom")
+var enableCustomHosts = flag.Bool("enable-custom-hosts", false, "Flag to enable hosts to be custom")
 
 var dnsProvider = flag.String("dns-provider", "aws", "The DNS provider being used [aws, fake]")
 
@@ -133,6 +133,7 @@ func main() {
 		// 	Name:      "hosts",
 		// 	Namespace: "default",
 		// },
+		CustomHostsEnabled: enableCustomHosts,
 	}
 	ingressController := ingress.NewController(controllerConfig)
 

--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -34,6 +34,8 @@ var region = flag.String("region", "eu-central-1", "the region we should target 
 var kubecontext = flag.String("context", "", "Context to use in the Kubeconfig file, instead of the current context")
 
 var domain = flag.String("domain", "hcpapps.net", "The domain to use to expose ingresses")
+var customHosts = flag.Bool("custom-hosts", true, "Flag to enable hosts to be custom")
+
 var dnsProvider = flag.String("dns-provider", "aws", "The DNS provider being used [aws, fake]")
 
 func main() {

--- a/pkg/cluster/mapper.go
+++ b/pkg/cluster/mapper.go
@@ -9,12 +9,13 @@ import (
 )
 
 const (
-	LABEL_HCG_HOST           = "kuadrant.dev/hcg.host"
-	ANNOTATION_HCG_WORKSPACE = "kuadrant.dev/hcg.workspace"
-	ANNOTATION_HCG_NAMESPACE = "kuadrant.dev/hcg.namespace"
-	LABEL_HCG_MANAGED        = "kuadrant.dev/hcg.managed"
-	ANNOTATION_HCG_HOST      = "kuadrant.dev/host.generated"
-	LABEL_OWNED_BY           = "kcp.dev/owned-by"
+	LABEL_HCG_HOST                      = "kuadrant.dev/hcg.host"
+	ANNOTATION_HCG_WORKSPACE            = "kuadrant.dev/hcg.workspace"
+	ANNOTATION_HCG_NAMESPACE            = "kuadrant.dev/hcg.namespace"
+	LABEL_HCG_MANAGED                   = "kuadrant.dev/hcg.managed"
+	ANNOTATION_HCG_HOST                 = "kuadrant.dev/host.generated"
+	ANNOTATION_HCG_CUSTOM_HOST_REPLACED = "kuadrant.dev/custom-hosts.replaced"
+	LABEL_OWNED_BY                      = "kcp.dev/owned-by"
 )
 
 type context struct {

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -83,7 +83,6 @@ type ControllerConfig struct {
 	TLSEnabled            bool
 	CertProvider          tls.Provider
 	HostResolver          net.HostResolver
-	EnvoyListenPort       *uint
 	CustomHostsEnabled    *bool
 }
 

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -52,6 +52,7 @@ func NewController(config *ControllerConfig) *Controller {
 			hostResolver,
 			net.DefaultInterval,
 		),
+		customHosts: config.CustomHosts,
 	}
 	c.hostsWatcher.OnChange = c.synchronisedEnque()
 
@@ -82,6 +83,8 @@ type ControllerConfig struct {
 	TLSEnabled            bool
 	CertProvider          tls.Provider
 	HostResolver          net.HostResolver
+	EnvoyListenPort       *uint
+	CustomHosts           *bool
 }
 
 type Controller struct {
@@ -97,6 +100,7 @@ type Controller struct {
 	tracker               tracker
 	hostResolver          net.HostResolver
 	hostsWatcher          *net.HostsWatcher
+	customHosts           *bool
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -52,7 +52,7 @@ func NewController(config *ControllerConfig) *Controller {
 			hostResolver,
 			net.DefaultInterval,
 		),
-		customHosts: config.CustomHosts,
+		customHostsEnabled: config.CustomHostsEnabled,
 	}
 	c.hostsWatcher.OnChange = c.synchronisedEnque()
 
@@ -84,7 +84,7 @@ type ControllerConfig struct {
 	CertProvider          tls.Provider
 	HostResolver          net.HostResolver
 	EnvoyListenPort       *uint
-	CustomHosts           *bool
+	CustomHostsEnabled    *bool
 }
 
 type Controller struct {
@@ -100,7 +100,7 @@ type Controller struct {
 	tracker               tracker
 	hostResolver          net.HostResolver
 	hostsWatcher          *net.HostsWatcher
-	customHosts           *bool
+	customHostsEnabled    *bool
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -3,7 +3,6 @@ package ingress
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/rs/xid"
 
@@ -26,9 +25,6 @@ import (
 const (
 	clusterLabel = "kcp.dev/cluster"
 	ownedByLabel = "kcp.dev/owned-by"
-
-	hostGeneratedAnnotation = "kuadrant.dev/host.generated"
-	customHostReplaced      = "kuadrant.dev/custom-hosts.replaced"
 
 	manager                 = "kcp-ingress"
 	cascadeCleanupFinalizer = "kcp.dev/cascade-cleanup"
@@ -544,8 +540,8 @@ func ingressKey(ingress *networkingv1.Ingress) interface{} {
 }
 
 func (c *Controller) replaceCustomHosts(ctx context.Context, ingress *networkingv1.Ingress) error {
-	generatedHost := ingress.Annotations[hostGeneratedAnnotation]
-	hosts := []interface{}{}
+	generatedHost := ingress.Annotations[cluster.ANNOTATION_HCG_HOST]
+	hosts := []string{}
 	for i, rule := range ingress.Spec.Rules {
 		if rule.Host != generatedHost {
 			ingress.Spec.Rules[i].Host = generatedHost
@@ -553,15 +549,35 @@ func (c *Controller) replaceCustomHosts(ctx context.Context, ingress *networking
 		}
 	}
 
-	//TODO: TLS
+	// clean up replaced hosts from the tls list
+	removeHostsFromTLS(hosts, ingress)
 
 	if len(hosts) > 0 {
-		ingress.Annotations[customHostReplaced] = fmt.Sprintf(" replaced custom hosts ("+strings.Repeat("%s ", len(hosts))+") to the glbc host due to custom host policy not being allowed",
-			hosts...)
+		ingress.Annotations[cluster.ANNOTATION_HCG_CUSTOM_HOST_REPLACED] = fmt.Sprintf(" replaced custom hosts %v to the glbc host due to custom host policy not being allowed",
+			hosts)
 		if _, err := c.kubeClient.Cluster(ingress.ClusterName).NetworkingV1().Ingresses(ingress.Namespace).Update(ctx, ingress, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func removeHostsFromTLS(hostsToRemove []string, ingress *networkingv1.Ingress) {
+	for _, host := range hostsToRemove {
+		for i, tls := range ingress.Spec.TLS {
+			hosts := tls.Hosts
+			for j, ingressHost := range tls.Hosts {
+				if ingressHost == host {
+					hosts = append(hosts[:j], hosts[j+1:]...)
+				}
+			}
+			// if there are no hosts remaning remove the entry for tls
+			if len(hosts) == 0 {
+				ingress.Spec.TLS[i] = networkingv1.IngressTLS{}
+			} else {
+				ingress.Spec.TLS[i].Hosts = hosts
+			}
+		}
+	}
 }

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -78,6 +78,12 @@ func (c *Controller) reconcileRoot(ctx context.Context, ingress *networkingv1.In
 		return nil
 	}
 
+	// verifies custom hosts and if they are present and the flag is set to false
+	// the reconciliation will fail
+	if !*c.customHosts && validateCustomHosts(ingress, *c.domain) {
+		return fmt.Errorf("failed ingress '%s' reconciliation due to custom hosts", ingress.Name)
+	}
+
 	AddFinalizer(ingress, cascadeCleanupFinalizer)
 	if ingress.Annotations == nil || ingress.Annotations[cluster.ANNOTATION_HCG_HOST] == "" {
 		// Let's assign it a global hostname if any


### PR DESCRIPTION
This PR adds a policy to allow the creation of custom hosts by setting a flag `-enable-custom-hosts` to the ingress controller, if the flag is not set any custom hosts defined in the ingress object will be replaced to the ingress generated host, this policy is required to prevent custom hosts from being used at workspace level so traffic can't be stolen from a particular domain.

>Any replaced host will be reported via the annotation `kuadrant.dev/custom-hosts.replaced` 

TODO: TLS might need to be changed to use the cert created for the generated host

## Verification steps

1. Run the ingress controller with the `-enable-custom-hosts` set to false
 ```bash
 ./bin/ingress-controller -kubeconfig .kcp/admin.kubeconfig -enable-custom-hosts=false -dns-provider fake
```
2. Create an ingress object using a different host from the ingress generated host 
```
kubectl -n default apply -f -<<EOF
  apiVersion: networking.k8s.io/v1
  kind: Ingress
  metadata:
    name: ingress-domain
  spec:
    rules:
      - host: hcpapps.net
        http:
          paths:
            - path: /
              pathType: Prefix
              backend:
                service:
                  name: httpecho-1
                  port:
                    number: 80
      - host: my-hostname.kcp-apps.127.0.0.1.nip.io
        http:
          paths:
            - path: /
              pathType: Prefix
              backend:
                service:
                  name: httpecho-2
                  port:
                    number: 80
EOF
```
3. Verify in the ingress object was created with the ingress generated host and the annotation `kuadrant.dev/custom-hosts.replaced` is present listing the replaced hosts
```bash
$ kubectl get ingress ingress-domain  -n custom-hosts -o json | jq .metadata.annotations | grep kuadrant.dev/custom-hosts.replaced

> "kuadrant.dev/custom-hosts.replaced": " replaced custom hosts (my-hostname.kcp-apps.127.0.0.1.nip.io my-hostname.kcp-apps.127.0.0.1.nip.io ) to the glbc host due to custom host policy not being allowed",
```