### PR TITLE
Add basic ci checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          only-new-issues: true
+          args: --timeout=5m
+
+  codegen:
+    name: codegen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - name: Check generate
+        run: make verify-generate
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - run: make build
+      - run: PATH="${PATH}:$(pwd)/bin/" make test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,5 @@
+# https://golangci-lint.run/usage/linters/
+linters:
+  enable:
+    - gofmt
+    - misspell

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,84 @@
-all: vendor build
-.PHONY: all
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
+
 NUM_CLUSTERS := 2
 KCP_BRANCH := release-prototype-2
-# go-get-tool will 'go get' any package $2 and install it to $1.
-# backing up and recovering the go.mod/go.sum as go install doesnt work
-# with project that use replacement directives, no time for a nicer solution.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-echo "Downloading $(2)" ;\
-mkdir -p $(PROJECT_DIR)/tmp ;\
-cp $(PROJECT_DIR)/{go.mod,go.sum} $(PROJECT_DIR)/tmp ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-cp $(PROJECT_DIR)/tmp/{go.mod,go.sum} $(PROJECT_DIR)/ ;\
-}
-endef
 
-build:
-	go build -o bin ./cmd/...
-.PHONY: build
+.PHONY: all
+all: build
 
-vendor:
+##@ General
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
+.PHONY: clean
+clean: ## Clean up temporary files.
+	-rm -rf ./.kcp
+	-rm -f ./bin/*
+	-rm -rf ./tmp
+
+generate: generate-deepcopy generate-crd generate-client ## Generate code containing DeepCopy method implementations, CustomResourceDefinition objects and Clients.
+
+generate-deepcopy: controller-gen
+	cd pkg/apis/kuadrant && $(CONTROLLER_GEN) paths="./..." object
+
+generate-crd: controller-gen
+	cd pkg/apis/kuadrant && $(CONTROLLER_GEN) crd paths=./... output:crd:artifacts:config=../../../config/crd output:crd:dir=../../../config/crd crd:crdVersions=v1 && rm -rf ./config
+
+generate-client:
+	./scripts/gen_client.sh
+
+vendor: ## Vendor the dependencies.
 	go mod tidy
 	go mod vendor
 .PHONY: vendor
 
-KIND = $(shell pwd)/bin/kind
-kind:
-	$(call go-get-tool,$(KIND),sigs.k8s.io/kind@v0.11.1)
+.PHONY: fmt
+fmt: ## Run go fmt against code.
+	go fmt ./...
 
-# Not ideal, fix when possible.
+.PHONY: vet
+vet: ## Run go vet against code.
+	go vet ./...
+
+lint: ## Run golangci-lint against code.
+	golangci-lint run ./...
+.PHONY: lint
+
+.PHONY: test
+test: generate ## Run tests.
+	#ToDo Implement `test` target
+
+##@ CI
+
+#Note, these targets are expected to run in a clean CI enviornment.
+
+.PHONY: verify-generate
+verify-generate: generate ## Verify generate update.
+	git diff --exit-code
+
+##@ Build
+
+build: ## Build the project.
+	go build -o bin ./cmd/...
+.PHONY: build
+
+.PHONY: docker-build
+docker-build: ## Build docker image.
+	#ToDo Implement `docker-build` target
+
+##@ Deployment
+
+.PHONY: local-setup
+local-setup: clean build kind kcp ## Setup kcp locally using kind.
+	./utils/local-setup.sh -c ${NUM_CLUSTERS}
+
 KCP = $(shell pwd)/bin/kcp
-kcp:
+kcp: ## Download kcp locally.
 	rm -rf ./tmp/kcp
 	git clone --depth=1 --branch ${KCP_BRANCH} https://github.com/kuadrant/kcp ./tmp/kcp
 	cd ./tmp/kcp && make
@@ -49,30 +93,13 @@ kcp:
 	cp ./tmp/kcp/bin/virtual-workspaces $(shell pwd)/bin
 	rm -rf ./tmp/kcp
 
-.PHONY: local-setup
-local-setup: clean build kind kcp
-	./utils/local-setup.sh -c ${NUM_CLUSTERS}
-
-.PHONY: clean
-clean:
-	-rm -rf ./.kcp
-	-rm -f ./bin/*
-	-rm -rf ./tmp
-
-generate: generate-deepcopy generate-crd generate-client
-
-generate-deepcopy: controller-gen
-	cd pkg/apis/kuadrant && $(CONTROLLER_GEN) paths="./..." object
-
-generate-crd: controller-gen
-	cd pkg/apis/kuadrant && $(CONTROLLER_GEN) crd paths=./... output:crd:artifacts:config=../../../config/crd output:crd:dir=../../../config/crd crd:crdVersions=v1 && rm -rf ./config
-
-generate-client:
-	./scripts/gen_client.sh
-
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
+
+KIND = $(shell pwd)/bin/kind
+kind: ## Download kind locally if necessary.
+	$(call go-get-tool,$(KIND),sigs.k8s.io/kind@v0.11.1)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.22.2
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.21.4
+	k8s.io/code-generator v0.0.0-00010101000000-000000000000
 	k8s.io/klog/v2 v2.30.0
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 )

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20220210121228
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:0xHdTqpGRk94GXkfb/BusWREH3MLNiN7rhjiDu+W0IQ=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20220210121228-50b2affb6ca1 h1:86ChgGnyvbDPZYqx2jPbJzK31B7OkU3IWZ+PotMzubU=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:8EW66ZxqXWRv5gHB91chqPslhH0CYNvLWLOCEIj8gHE=
+github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20220210121228-50b2affb6ca1 h1:gUcWHu0hEP7Hv+uoODJ5sBQPpPRRrHLRYwpQhBW9QIs=
+github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:3Oz9SHvALoA5bm6QReTojYUzTDd957L3aMY0/DkPzBY=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20220210121228-50b2affb6ca1 h1:uVO5bbKcYrWzEEkBIYxJgIFaKKeksf4voz8a0NYlIR0=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20220210121228-50b2affb6ca1/go.mod h1:4IWNaSBE0Z02qopZW9+g2IbDAqFG+1alRB847qhaIco=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -598,6 +600,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -974,6 +977,7 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,0 +1,7 @@
+//go:build tools
+// +build tools
+
+package tools
+
+// This package imports things required by this repository, to force `go mod` to see them as dependencies
+import _ "k8s.io/code-generator"


### PR DESCRIPTION
**Update Makefile**
* Organise Makefile to be more like a kubebuilder generated file.
* Add make targets, help, fmt, vet, verify-generate, docker-build(Not implemented) and test(Not implemented).
* Remove duplicate go-get-tool definition.
* Adds a new make target to run golangci-lint `make lint` and a golangci config that is configured to run the default linters plus format checks (gofmt) https://golangci-lint.run/usage/configuration/.

**Add CI GitHub Workflow**
Adds a github action workflow to run basic CI checks on pull requests and any updates made directly to main. Current checks are `lint` which runs golangci-lint, `codegen` which checks all generated files are correct and `test`  which runs `make test` (Not currently implemented).

Note, the lint action is expected to fail on main when this merged since there are issues in the current code. On PRs it's only checking for new issues.

**Add tools package**
Add tools package to import things required by this repository to force `go mod` to see them as dependencies. Currently imports the code-generator package required by the gen_client.sh script.