### PR TITLE
Add image build

### DIFF
--- a/.github/workflows/kcp-glbc-image.yaml
+++ b/.github/workflows/kcp-glbc-image.yaml
@@ -1,0 +1,52 @@
+name: Build and Publish KCP GLBC Image
+
+on:
+  push:
+    branches: [ '*' ]
+    tags: [ '*' ]
+
+env:
+  IMG_TAGS: ${{ github.ref_name }}
+  IMG_REGISTRY_HOST: quay.io
+  IMG_REGISTRY_ORG: kuadrant
+  MAIN_BRANCH_NAME: main
+
+jobs:
+  build:
+    name: Build and Publish KCP GLBC Image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Add short sha tag
+        id: add-sha-tag
+        run: |
+          echo "IMG_TAGS=$(echo ${{ github.sha }} | cut -b -7) ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+
+      - name: Add latest tag
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+
+      - name: Build KCP GLBC Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: kcp-glbc
+          tags: ${{ env.IMG_TAGS }}
+          containerfiles: |
+            ./Dockerfile
+
+      - name: Push to quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Build the manager binary
+FROM golang:1.17 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+# Build
+RUN mkdir bin; CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin ./cmd/...
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder workspace/bin/* /
+USER 65532:65532
+
+ENTRYPOINT ["/ingress-controller"]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ SHELL := /usr/bin/env bash
 NUM_CLUSTERS := 2
 KCP_BRANCH := release-prototype-2
 
+IMAGE_TAG_BASE ?= quay.io/kuadrant/kcp-glbc
+IMAGE_TAG ?= latest
+IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
+
 .PHONY: all
 all: build
 
@@ -69,7 +73,7 @@ build: ## Build the project.
 
 .PHONY: docker-build
 docker-build: ## Build docker image.
-	#ToDo Implement `docker-build` target
+	docker build -t ${IMG} .
 
 ##@ Deployment
 


### PR DESCRIPTION
* Add Dockerfile
* Add target to makefile for docker-build (dev use only)
* Add GitHub action to build and publish image to quay.io. Publishes images for any branch or tag pushed to the repo (not PRs), adds tags: short commit hash (git rev-parse --short HEAD), ref_name (branch/tag name) and latest (main branch only).

Run of this branch (pushed to "kuadrant" rather than my fork to test): https://github.com/Kuadrant/kcp-glbc/actions/runs/1981111707
Quay repo: https://quay.io/repository/kuadrant/kcp-glbc?tab=tags

Test the image locally with:

```
docker run --rm --network="host" -u $UID -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_DNS_PUBLIC_ZONE_ID=$AWS_DNS_PUBLIC_ZONE_ID -e HCG_LE_EMAIL=$HCG_LE_EMAIL -v "$(pwd)/.kcp":/.kcp:z -v "$(pwd)/tmp":/.kcptmp:z quay.io/kuadrant/kcp-glbc:add_docker_build -kubeconfig .kcp/admin.kubeconfig -glbc-kubeconfig .kcptmp/kcp-cluster-glbc-control.kubeconfig
```
