### PR TITLE
HCG-70: DNS Health checks

### DIFF
--- a/docs/dns/health-checks.md
+++ b/docs/dns/health-checks.md
@@ -1,0 +1,61 @@
+# Health Check reconciliation
+
+The GLB Controller has the ability to reconcile health checks for the DNS records
+that it maintains. Currently it supports reconciliation of Route 53 health checks,
+where a health check is created for each Route 53 record. For example, given the
+following endpoints in the `DNSRecord` CR:
+
+```yaml
+endpoints:
+  - dnsName: c92nein5runjgpioik5g.sf.hcpapps.net
+    providerSpecific:
+    - name: aws/weight
+      value: "100"
+    recordTTL: 60
+    recordType: A
+    setIdentifier: 3.230.19.134
+    targets:
+    - 3.230.19.134
+  - dnsName: c92nein5runjgpioik5g.sf.hcpapps.net
+    providerSpecific:
+    - name: aws/weight
+      value: "100"
+    recordTTL: 60
+    recordType: A
+    setIdentifier: 52.1.106.34
+    targets:
+    - 52.1.106.34
+  - dnsName: c92nein5runjgpioik5g.sf.hcpapps.net
+    providerSpecific:
+    - name: aws/weight
+      value: "100"
+    recordTTL: 60
+    recordType: A
+    setIdentifier: 34.148.111.106
+    targets:
+    - 34.148.111.106
+```
+
+3 health checks will be created pointing to the endpoint address (the `setIdentifier` value)
+using the `dnsName` value as the `Host` header.
+
+In order to enable health check reconciliation. Add the `kuadrant.experimental/health-endpoint`
+annotation to the Ingress. The value is the path of the health endpoint of the service.
+
+Other configuration values can be set as annotations:
+
+| Annotation | Description | Default value |
+| ---------- | ----------- | ------------- |
+| `kuadrant.experimental/health-endpoint` |  Path of the health endpoint for the target service | _Required_ |
+| `kuadrant.experimental/health-port` |  Port where the health checks will be performed | 80 |
+| `kuadrant.experimental/health-protocol` |  Protocol to be used by the health checks to request the endpoint | `HTTP` |
+| `kuadrant.experimental/health-failure-threshold` | Number of consecutive health checks that the endpoint can fail in order to be considered unhealthy | 3 |
+
+## Failover
+
+> ⚠️ Note that all endpoints must be accessible to the AWS Health Checkers. If
+> they are not, they will be marked as unhealthy and unavailable to DNS requests
+
+
+The health checks will be associated to each Route 53 weighted record. In the event
+of an unhealthy endpoint, Route 53 will stop serving that address to DNS clients

--- a/pkg/apis/kuadrant/v1/types.go
+++ b/pkg/apis/kuadrant/v1/types.go
@@ -179,3 +179,64 @@ type DNSRecordList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []DNSRecord `json:"items"`
 }
+
+func (endpoint *Endpoint) SetProviderSpecific(name, value string) {
+	var property *ProviderSpecificProperty
+
+	if endpoint.ProviderSpecific == nil {
+		endpoint.ProviderSpecific = ProviderSpecific{}
+	}
+
+	for _, pair := range endpoint.ProviderSpecific {
+		if pair.Name == name {
+			property = &pair
+		}
+	}
+
+	if property != nil {
+		property.Value = value
+		return
+	}
+
+	endpoint.ProviderSpecific = append(endpoint.ProviderSpecific, ProviderSpecificProperty{
+		Name:  name,
+		Value: value,
+	})
+}
+
+func (endpoint *Endpoint) GetProviderSpecific(name string) (string, bool) {
+	for _, property := range endpoint.ProviderSpecific {
+		if property.Name == name {
+			return property.Value, true
+		}
+	}
+
+	return "", false
+}
+
+func (endpoint *Endpoint) DeleteProviderSpecific(name string) bool {
+	if endpoint.ProviderSpecific == nil {
+		return false
+	}
+
+	deleted := false
+	providerSpecific := make(ProviderSpecific, 0, len(endpoint.ProviderSpecific))
+	for _, pair := range endpoint.ProviderSpecific {
+		if pair.Name == name {
+			deleted = true
+		} else {
+			providerSpecific = append(providerSpecific, pair)
+		}
+	}
+
+	endpoint.ProviderSpecific = providerSpecific
+	return deleted
+}
+
+func (endpoint *Endpoint) GetAddress() (string, bool) {
+	if endpoint.SetIdentifier == "" || len(endpoint.Targets) == 0 {
+		return "", false
+	}
+
+	return string(endpoint.Targets[0]), true
+}

--- a/pkg/cluster/mapper.go
+++ b/pkg/cluster/mapper.go
@@ -16,6 +16,10 @@ const (
 	ANNOTATION_HCG_HOST                 = "kuadrant.dev/host.generated"
 	ANNOTATION_HCG_CUSTOM_HOST_REPLACED = "kuadrant.dev/custom-hosts.replaced"
 	LABEL_OWNED_BY                      = "kcp.dev/owned-by"
+
+	// Experimental
+
+	ANNOTATION_HEALTH_CHECK_PREFIX = "kuadrant.experimental/health-"
 )
 
 type context struct {

--- a/pkg/dns/aws/health.go
+++ b/pkg/dns/aws/health.go
@@ -1,0 +1,241 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	v1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
+	"github.com/kuadrant/kcp-glbc/pkg/dns"
+	"github.com/rs/xid"
+	"k8s.io/klog/v2"
+)
+
+const (
+	idTag = "kuadrant.dev/healthcheck"
+)
+
+var (
+	callerReference func(id string) *string
+)
+
+type Route53HealthCheckReconciler struct {
+	client *route53.Route53
+}
+
+var _ dns.HealthCheckReconciler = &Route53HealthCheckReconciler{}
+
+func NewRoute53HealthCheckReconciler(client *route53.Route53) *Route53HealthCheckReconciler {
+	return &Route53HealthCheckReconciler{
+		client: client,
+	}
+}
+
+func (r *Route53HealthCheckReconciler) Reconcile(ctx context.Context, spec dns.HealthCheckSpec, endpoint *v1.Endpoint) error {
+	healthCheck, exists, err := r.findHealthCheck(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if healthCheck != nil {
+			endpoint.SetProviderSpecific(ProviderSpecificHealthCheckID, *healthCheck.Id)
+		}
+	}()
+
+	if exists {
+		return r.updateHealthCheck(ctx, spec, endpoint, healthCheck)
+	}
+
+	healthCheck, err = r.createHealthCheck(ctx, spec, endpoint)
+	return err
+}
+
+func (r *Route53HealthCheckReconciler) Delete(ctx context.Context, endpoint *v1.Endpoint) error {
+	healthCheck, found, err := r.findHealthCheck(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+
+	_, err = r.client.DeleteHealthCheckWithContext(ctx, &route53.DeleteHealthCheckInput{
+		HealthCheckId: healthCheck.Id,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	endpoint.DeleteProviderSpecific(ProviderSpecificHealthCheckID)
+	return err
+}
+
+func (c *Route53HealthCheckReconciler) findHealthCheck(ctx context.Context, endpoint *v1.Endpoint) (*route53.HealthCheck, bool, error) {
+	id, hasId := getHealthCheckId(endpoint)
+	if !hasId {
+		return nil, false, nil
+	}
+
+	response, err := c.client.GetHealthCheckWithContext(ctx, &route53.GetHealthCheckInput{
+		HealthCheckId: &id,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	return response.HealthCheck, true, nil
+
+}
+
+func (c *Route53HealthCheckReconciler) createHealthCheck(ctx context.Context, spec dns.HealthCheckSpec, endpoint *v1.Endpoint) (*route53.HealthCheck, error) {
+	address, _ := endpoint.GetAddress()
+	host := endpoint.DNSName
+
+	// Create the health check
+	output, err := c.client.CreateHealthCheck(&route53.CreateHealthCheckInput{
+
+		CallerReference: callerReference(spec.Id),
+
+		HealthCheckConfig: &route53.HealthCheckConfig{
+			IPAddress:                &address,
+			FullyQualifiedDomainName: &host,
+			Port:                     spec.Port,
+			ResourcePath:             &spec.Path,
+			Type:                     healthCheckType(spec.Protocol),
+			FailureThreshold:         spec.FailureThreshold,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the tag to identify it
+	_, err = c.client.ChangeTagsForResourceWithContext(ctx, &route53.ChangeTagsForResourceInput{
+		AddTags: []*route53.Tag{
+			{
+				Key:   aws.String(idTag),
+				Value: aws.String(spec.Id),
+			},
+			{
+				Key:   aws.String("Name"),
+				Value: &spec.Name,
+			},
+		},
+		ResourceId:   output.HealthCheck.Id,
+		ResourceType: aws.String(route53.TagResourceTypeHealthcheck),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return output.HealthCheck, nil
+}
+
+func (r *Route53HealthCheckReconciler) updateHealthCheck(ctx context.Context, spec dns.HealthCheckSpec, endpoint *v1.Endpoint, healthCheck *route53.HealthCheck) error {
+	diff := healthCheckDiff(healthCheck, spec, endpoint)
+	if diff == nil {
+		return nil
+	}
+
+	klog.Infof("Updating health check %s with diff %v", *healthCheck.Id, diff)
+
+	_, err := r.client.UpdateHealthCheckWithContext(ctx, diff)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// healthCheckDiff creates a `UpdateHealthCheckInput` object with the fields to
+// update on healthCheck based on the given spec.
+// If the health check matches the spec, returns `nil`
+func healthCheckDiff(healthCheck *route53.HealthCheck, spec dns.HealthCheckSpec, endpoint *v1.Endpoint) *route53.UpdateHealthCheckInput {
+	var result *route53.UpdateHealthCheckInput
+
+	diff := func() *route53.UpdateHealthCheckInput {
+		if result == nil {
+			result = &route53.UpdateHealthCheckInput{
+				HealthCheckId: healthCheck.Id,
+			}
+		}
+
+		return result
+	}
+
+	if !strValuesEqual(&endpoint.DNSName, healthCheck.HealthCheckConfig.FullyQualifiedDomainName) {
+		diff().FullyQualifiedDomainName = &endpoint.DNSName
+	}
+
+	address, _ := endpoint.GetAddress()
+	if !strValuesEqual(&address, healthCheck.HealthCheckConfig.IPAddress) {
+		diff().IPAddress = &address
+	}
+	if !strValuesEqual(&spec.Path, healthCheck.HealthCheckConfig.ResourcePath) {
+		diff().ResourcePath = &spec.Path
+	}
+	if !intValuesEqual(spec.Port, healthCheck.HealthCheckConfig.Port) {
+		diff().Port = spec.Port
+	}
+	if !intValuesEqual(spec.FailureThreshold, healthCheck.HealthCheckConfig.FailureThreshold) {
+		diff().FailureThreshold = spec.FailureThreshold
+	}
+
+	return result
+}
+
+func init() {
+	sid := xid.New()
+	callerReference = func(s string) *string {
+		return aws.String(fmt.Sprintf("%s.%s", s, sid))
+	}
+}
+
+func healthCheckType(protocol *dns.HealthCheckProtocol) *string {
+	if protocol == nil {
+		return nil
+	}
+
+	switch *protocol {
+	case dns.HealthCheckProtocolHTTP:
+		return aws.String(route53.HealthCheckTypeHttp)
+
+	case dns.HealthCheckProtocolHTTPS:
+		return aws.String(route53.HealthCheckTypeHttps)
+	}
+
+	return nil
+}
+
+func strValuesEqual(str1, str2 *string) bool {
+	if str1 == nil && str2 != nil {
+		return false
+	}
+	if str2 == nil && str1 != nil {
+		return false
+	}
+	if str1 == nil && str2 == nil {
+		return true
+	}
+
+	return *str1 == *str2
+}
+
+func intValuesEqual(int1, int2 *int64) bool {
+	if int1 == nil && int2 != nil ||
+		int2 == nil && int1 != nil {
+		return false
+	}
+	if int1 == nil && int2 == nil {
+		return true
+	}
+
+	return *int1 == *int2
+}
+
+func getHealthCheckId(endpoint *v1.Endpoint) (string, bool) {
+	return endpoint.GetProviderSpecific(ProviderSpecificHealthCheckID)
+}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -11,6 +11,9 @@ type Provider interface {
 
 	// Delete will delete record.
 	Delete(record *v1.DNSRecord, zone v1.DNSZone) error
+
+	// Get a health check reconciler for this provider
+	HealthCheckReconciler() HealthCheckReconciler
 }
 
 var _ Provider = &FakeProvider{}
@@ -19,3 +22,6 @@ type FakeProvider struct{}
 
 func (_ *FakeProvider) Ensure(record *v1.DNSRecord, zone v1.DNSZone) error { return nil }
 func (_ *FakeProvider) Delete(record *v1.DNSRecord, zone v1.DNSZone) error { return nil }
+func (*FakeProvider) HealthCheckReconciler() HealthCheckReconciler {
+	return &FakeHealthCheckReconciler{}
+}

--- a/pkg/dns/health.go
+++ b/pkg/dns/health.go
@@ -1,0 +1,40 @@
+package dns
+
+import (
+	"context"
+
+	v1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
+)
+
+type HealthCheckReconciler interface {
+	Reconcile(ctx context.Context, spec HealthCheckSpec, endpoint *v1.Endpoint) error
+
+	Delete(ctx context.Context, endpoint *v1.Endpoint) error
+}
+
+type HealthCheckSpec struct {
+	Id               string
+	Name             string
+	Port             *int64
+	FailureThreshold *int64
+	Protocol         *HealthCheckProtocol
+
+	Path string
+}
+
+type HealthCheckProtocol string
+
+const HealthCheckProtocolHTTP HealthCheckProtocol = "HTTP"
+const HealthCheckProtocolHTTPS HealthCheckProtocol = "HTTPS"
+
+type FakeHealthCheckReconciler struct{}
+
+func (*FakeHealthCheckReconciler) Reconcile(ctx context.Context, _ HealthCheckSpec, _ *v1.Endpoint) error {
+	return nil
+}
+
+func (*FakeHealthCheckReconciler) Delete(ctx context.Context, _ *v1.Endpoint) error {
+	return nil
+}
+
+var _ HealthCheckReconciler = &FakeHealthCheckReconciler{}

--- a/pkg/reconciler/dns/health.go
+++ b/pkg/reconciler/dns/health.go
@@ -1,0 +1,210 @@
+package dns
+
+import (
+	"context"
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	v1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
+	"github.com/kuadrant/kcp-glbc/pkg/cluster"
+	"github.com/kuadrant/kcp-glbc/pkg/dns"
+	"k8s.io/klog/v2"
+)
+
+// healthChecksConfig represents the user configuration for the health checks
+type healthChecksConfig struct {
+	Endpoint         string
+	Port             *int64
+	FailureThreshold *int64
+	Protocol         *dns.HealthCheckProtocol
+}
+
+// annotationsConfigMap contains the logic to map an annotation-based configuration
+// value into a mutation of the healthChecksConfig.
+var annotationsConfigMap = map[string]func(string, *healthChecksConfig) error{
+	"endpoint": notNilConfig(func(endpoint string, s *healthChecksConfig) error {
+		s.Endpoint = endpoint
+		return nil
+	}),
+	"port": notNilConfig(configInt64(func(port int64, c *healthChecksConfig) {
+		c.Port = &port
+	})),
+	"protocol": notNilConfig(func(protocol string, c *healthChecksConfig) error {
+		var value dns.HealthCheckProtocol
+		switch protocol {
+		case string(dns.HealthCheckProtocolHTTP):
+		case string(dns.HealthCheckProtocolHTTPS):
+			value = dns.HealthCheckProtocol(protocol)
+		}
+
+		if value == "" {
+			return fmt.Errorf("invalid protocol %s. Only supported values are HTTP and HTTPS", protocol)
+		}
+
+		c.Protocol = &value
+		return nil
+	}),
+	"failure-threshold": notNilConfig(configInt64(func(v int64, c *healthChecksConfig) {
+		c.FailureThreshold = &v
+	})),
+}
+
+func (c *Controller) ReconcileHealthChecks(ctx context.Context, dnsRecord *v1.DNSRecord) error {
+	config, err := configFromAnnotations(dnsRecord.Annotations)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+
+	if config == nil {
+		return c.reconcileHealthCheckDeletion(ctx, dnsRecord)
+	}
+
+	if err := validateHealthChecksConfig(config); err != nil {
+		return err
+	}
+
+	return c.reconcileHealthCheck(ctx, config, dnsRecord)
+}
+
+func (c *Controller) reconcileHealthCheck(ctx context.Context, config *healthChecksConfig, dnsRecord *v1.DNSRecord) error {
+	healthCheck := c.dnsProvider.HealthCheckReconciler()
+
+	for _, dnsEndpoint := range dnsRecord.Spec.Endpoints {
+		ok := false
+		if _, ok = dnsEndpoint.GetAddress(); !ok {
+			klog.Infof("Skipping health check creation for %s/%s. No address set", dnsRecord.Name, dnsEndpoint.DNSName)
+			continue
+		}
+
+		endpointId, err := idForEndpoint(dnsRecord, dnsEndpoint)
+		if err != nil {
+			return err
+		}
+
+		spec := dns.HealthCheckSpec{
+			Id:               endpointId,
+			Name:             fmt.Sprintf("%s-%s", dnsEndpoint.DNSName, dnsEndpoint.SetIdentifier),
+			Path:             config.Endpoint,
+			Port:             config.Port,
+			Protocol:         config.Protocol,
+			FailureThreshold: config.FailureThreshold,
+		}
+
+		klog.Infof("Reconciling health check for endpoint %s@%s", dnsEndpoint.DNSName, dnsEndpoint.SetIdentifier)
+
+		err = healthCheck.Reconcile(ctx, spec, dnsEndpoint)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) reconcileHealthCheckDeletion(ctx context.Context, dnsRecord *v1.DNSRecord) error {
+	reconciler := c.dnsProvider.HealthCheckReconciler()
+
+	for _, zone := range dnsRecord.Status.Zones {
+		for _, endpoint := range zone.Endpoints {
+			if err := reconciler.Delete(ctx, endpoint); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// idForEndpoint returns a unique identifier for an endpoint
+func idForEndpoint(dnsRecord *v1.DNSRecord, endpoint *v1.Endpoint) (string, error) {
+	hash := md5.New()
+	if _, err := io.WriteString(hash, fmt.Sprintf("%s/%s@%s", dnsRecord.Name, endpoint.SetIdentifier, endpoint.DNSName)); err != nil {
+		return "", fmt.Errorf("Unexpected error creating ID for endpoint %s", endpoint.SetIdentifier)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+// configFromAnnotations populates a healthChecksConfig instance from the
+// annotations map. If no relevant annotation are found, returns nil
+func configFromAnnotations(annotations map[string]string) (*healthChecksConfig, error) {
+	if annotations == nil {
+		return nil, nil
+	}
+
+	var result *healthChecksConfig
+
+	for k, v := range annotations {
+		// The annotation is not for the health check. Skip it
+		if !strings.HasPrefix(k, cluster.ANNOTATION_HEALTH_CHECK_PREFIX) {
+			continue
+		}
+
+		// Get the configuration key
+		field := strings.TrimPrefix(k, cluster.ANNOTATION_HEALTH_CHECK_PREFIX)
+
+		// Get the set value function for the configuration key
+		setValue, ok := annotationsConfigMap[field]
+		if !ok {
+			return nil, fmt.Errorf("invalid value for annotation %s: %s", k, v)
+		}
+
+		if result == nil {
+			result = &healthChecksConfig{}
+		}
+
+		// Apply the value into the resulting configuration instance
+		if err := setValue(v, result); err != nil {
+			return nil, fmt.Errorf("invalid value for annotation %s: %v", k, err)
+		}
+
+	}
+
+	return result, nil
+}
+
+func validateHealthChecksConfig(config *healthChecksConfig) error {
+	if config == nil {
+		return errors.New("health checks config can't be nil")
+	}
+
+	if config.Endpoint == "" {
+		return errors.New("endpoint is a required value to configure health checks")
+	}
+	if config.Port == nil {
+		config.Port = aws.Int64(80)
+	}
+	if config.Protocol == nil {
+		defaultProtocol := dns.HealthCheckProtocolHTTP
+		config.Protocol = &defaultProtocol
+	}
+
+	return nil
+}
+
+func configInt64(f func(int64, *healthChecksConfig)) func(string, *healthChecksConfig) error {
+	return func(s string, c *healthChecksConfig) error {
+		intValue, err := strconv.Atoi(s)
+		if err != nil {
+			return err
+		}
+
+		f(int64(intValue), c)
+		return nil
+	}
+}
+
+func notNilConfig(f func(string, *healthChecksConfig) error) func(string, *healthChecksConfig) error {
+	return func(s string, hcc *healthChecksConfig) error {
+		if hcc == nil {
+			return errors.New("health check config can't be nil")
+		}
+
+		return f(s, hcc)
+	}
+}


### PR DESCRIPTION
## Reconcile health checks for DNSRecords

Adds the ability for users to set an annotation in the Ingress object that will result in health checks being reconciled for the endpoints.

### Verification steps

>  ⚠️ The IP address specified in Route 53 health checks must be a public address. In order to verify this PR you need to use publicly accessible clusters

1. Start KCP and add the clusters to be used for verification
2. Start the kcp-glbc
    ```sh
    # Assuming a .env with the AWS credentials
    source .env && ./bin/ingress-controller -kubeconfig .kcp/admin.kubeconfig -glbc-kubeconfig ./tmp/kcp-cluster-glbc-control.kubeconfig -dns-provider aws -domain sf.hcpapps.net
    ```
3. Create the sample resources
    ```sh
    kubectl create namespace default
    kubectl apply -n default -f samples/echo-service/echo.yaml
    ```
4. A service will be created and the workload propagated to the clusters. An Ingress object will be created as well, and the DNSRecord object will be propagated by the controller, and the records will be reconciled in Route 53.
    * Edit the Ingress object to specify a health endpoint:
        ```sh
        kubectl edit ingress/ingress-nondomain -n default
        ```
        Add the following annotation
        ```yaml
        kuadrant.dev/health-endpoint: /
        ```
5. The controller will propagate the annotation to the DNSRecord object. Verify that the annotation is set 
    ```sh
    kubectl get dnsrecords/ingress-nondomain -o yaml
    ```
6. The controller will create one health check per weighted record, and update the record to reference its health check.
7. In one of the clusters, scale down the workload and verify that the health check becomes unhealthy
8. Perform DNS lookups against the GLB host and verify that the DNS doesn't respond with the unhealthy endpoint