### PR TITLE
Add a workaround for placement not happening on ingress objects

### DIFF
--- a/e2e/support/core.go
+++ b/e2e/support/core.go
@@ -44,6 +44,10 @@ func Annotations(object metav1.Object) map[string]string {
 	return object.GetAnnotations()
 }
 
+func Labels(object metav1.Object) map[string]string {
+	return object.GetLabels()
+}
+
 func ConditionStatus(conditionType conditionsapi.ConditionType) func(getter conditionsutil.Getter) corev1.ConditionStatus {
 	return func(getter conditionsutil.Getter) corev1.ConditionStatus {
 		c := conditionsutil.Get(getter, conditionType)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/miekg/dns v1.1.34
 	github.com/onsi/gomega v1.17.0
 	github.com/rs/xid v1.3.0
+	github.com/zmb3/gogetdoc v0.0.0-20190228002656-b37376c5da6a // indirect
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.5
 	k8s.io/apiserver v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -1143,6 +1143,8 @@ github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
+github.com/zmb3/gogetdoc v0.0.0-20190228002656-b37376c5da6a h1:00UFliGZl2UciXe8o/2iuEsRQ9u7z0rzDTVzuj6EYY0=
+github.com/zmb3/gogetdoc v0.0.0-20190228002656-b37376c5da6a/go.mod h1:ofmGw6LrMypycsiWcyug6516EXpIxSbZ+uI9ppGypfY=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
@@ -1517,6 +1519,7 @@ golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181207195948-8634b1ecd393/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -1,0 +1,77 @@
+package placement
+
+import (
+	"fmt"
+
+	kcp "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type Placer interface {
+	PlaceRoutingObj([]*corev1.Service, runtime.Object) error
+}
+
+func NewPlacer() *Placement {
+	return &Placement{}
+}
+
+type Placement struct {
+}
+
+// PlaceRoutingObj will ensure the right placement label is on an routing object such as ingress.
+// Note this may not be needed long term (https://github.com/kcp-dev/kcp/issues/896)
+func (p *Placement) PlaceRoutingObj(services []*corev1.Service, obj runtime.Object) error {
+	placementValue, err := p.place(services)
+	if err != nil {
+		return err
+	}
+	if placementValue == "" {
+		// nothing to do service has not been placed yet
+		return nil
+	}
+	ac := meta.NewAccessor()
+	existingLabels, err := ac.Labels(obj)
+	if err != nil {
+		return err
+	}
+	if existingLabels == nil {
+		existingLabels = map[string]string{}
+	}
+	existingLabels[kcp.ClusterLabel] = placementValue
+	return ac.SetLabels(obj, existingLabels)
+}
+
+func (p *Placement) place(services []*corev1.Service) (string, error) {
+	if len(services) == 0 {
+		// cant do anything here
+		return "", fmt.Errorf("cannot place ingress, there are no services associated with it")
+	}
+	// if there is more than one service for this ingress check they are both placed on the same cluster. If not we cannot currently send the ingress to two clusters so error out (will be solved by the location API)
+	var clusterLoc string
+
+	for _, s := range services {
+		if !hasClusterLabel(s.Labels) {
+			continue
+		}
+		currentLoc := s.Labels[kcp.ClusterLabel]
+		if clusterLoc != "" && currentLoc != clusterLoc {
+			return "", fmt.Errorf("cannot place ingress. multiple services detected with different cluster labels")
+		}
+		clusterLoc = s.Labels[kcp.ClusterLabel]
+	}
+
+	return clusterLoc, nil
+}
+
+func hasClusterLabel(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+	val, ok := labels[kcp.ClusterLabel]
+	if !ok || val == "" {
+		return false
+	}
+	return true
+}

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -1,0 +1,146 @@
+package placement_test
+
+import (
+	"fmt"
+	"testing"
+
+	kcp "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
+	"github.com/kuadrant/kcp-glbc/pkg/placement"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newIngress(labels map[string]string) *networkingv1.Ingress {
+	return &networkingv1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: labels,
+		},
+	}
+}
+
+func newService(labels map[string]string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: labels,
+		},
+	}
+}
+
+func TestPlacement_Ingress(t *testing.T) {
+
+	cases := []struct {
+		Name        string
+		Ingress     func() *networkingv1.Ingress
+		ExpectError bool
+		Services    func() []*corev1.Service
+		Validate    func(*networkingv1.Ingress) error
+	}{
+		{
+			Name: "Test place ingress based on service placement label",
+			Ingress: func() *networkingv1.Ingress {
+				return newIngress(map[string]string{"some": "label"})
+			},
+			Services: func() []*corev1.Service {
+				return []*corev1.Service{
+					newService(map[string]string{kcp.ClusterLabel: "value"}),
+				}
+			},
+			ExpectError: false,
+			Validate: func(i *networkingv1.Ingress) error {
+				if i == nil {
+					return fmt.Errorf("no ingress. Expected an ingress")
+				}
+				_, ok := i.Labels[kcp.ClusterLabel]
+				if !ok {
+					return fmt.Errorf("expected the placement label %s but found none ", kcp.ClusterLabel)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Test no placement when no service placement label",
+			Ingress: func() *networkingv1.Ingress {
+				return newIngress(map[string]string{"some": "label"})
+			},
+			Services: func() []*corev1.Service {
+				return []*corev1.Service{
+					newService(map[string]string{"some": "value"}),
+				}
+			},
+			ExpectError: false,
+			Validate: func(i *networkingv1.Ingress) error {
+				if i == nil {
+					return fmt.Errorf("no ingress. Expected an ingress")
+				}
+				val, ok := i.Labels[kcp.ClusterLabel]
+				if ok {
+					return fmt.Errorf("did not expect the placement label %s but found  ", val)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Test no placement when no services",
+			Ingress: func() *networkingv1.Ingress {
+				return newIngress(map[string]string{"some": "label"})
+			},
+			Services: func() []*corev1.Service {
+				return []*corev1.Service{}
+			},
+			ExpectError: true,
+			Validate: func(i *networkingv1.Ingress) error {
+				if i == nil {
+					return fmt.Errorf("no ingress. Expected an ingress")
+				}
+				val, ok := i.Labels[kcp.ClusterLabel]
+				if ok {
+					return fmt.Errorf("did not expect the placement label %s but found  ", val)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Test no placement when multiple services with multiple placements",
+			Ingress: func() *networkingv1.Ingress {
+				return newIngress(map[string]string{"some": "label"})
+			},
+			Services: func() []*corev1.Service {
+				return []*corev1.Service{
+					newService(map[string]string{kcp.ClusterLabel: "some"}),
+					newService(map[string]string{kcp.ClusterLabel: "other"}),
+				}
+			},
+			ExpectError: true,
+			Validate: func(i *networkingv1.Ingress) error {
+				if i == nil {
+					return fmt.Errorf("no ingress. Expected an ingress")
+				}
+				val, ok := i.Labels[kcp.ClusterLabel]
+				if ok {
+					return fmt.Errorf("did not expect the placement label %s but found  ", val)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			p := placement.NewPlacer()
+			ingress := tc.Ingress()
+			err := p.PlaceRoutingObj(tc.Services(), ingress)
+			if tc.ExpectError && err == nil {
+				t.Fatalf("expected an error but got none")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect an error but got none")
+			}
+			if err := tc.Validate(ingress); err != nil {
+				t.Fatalf("ingress was invalid %v", err)
+			}
+
+		})
+	}
+
+}

--- a/pkg/reconciler/tls/secrets.go
+++ b/pkg/reconciler/tls/secrets.go
@@ -25,7 +25,6 @@ func (c *Controller) reconcile(ctx context.Context, secret *v1.Secret) error {
 	// may be a better way to filter these out TODO look at label selector in the controller
 	if err != nil && cluster.IsNoContextErr(err) {
 		// ignore this secret
-		klog.Infof("ignoring control cluster secret as doesn't have kcp context annotations", secret.Name)
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes #70 

This may be a temp fix depending on https://github.com/kcp-dev/kcp/issues/896
This also fixes an issue with closing a closed channel on the host watcher that was causing panics

Adds the placement label to ingress objects based on the placement label of the services the Ingress is targeting 
Update the Ingress e2e test to do the following

- create workspace
- create ns
- create deployment, ingress, service
- expect them to be scheduled to a workload cluster
- create another workload cluster
- schedule the ns to the new cluster
- expect everything to move to the new cluster
- validate the DNS entries are as expected