### PR TITLE
WIP Import glbc resources to new workspaces

### DIFF
--- a/cmd/kcp-glbc/main.go
+++ b/cmd/kcp-glbc/main.go
@@ -134,7 +134,8 @@ func main() {
 	if err != nil {
 		klog.Fatal(err)
 	}
-	kcpOrgInformerFactory := kcpInformers.NewSharedInformerFactory(kcpOrgClient.Cluster(logicalcluster.New("root:default:kcp-glbc")), resyncPeriod)
+	kcpOrgInformerFactory := kcpInformers.NewSharedInformerFactory(kcpOrgClient.Cluster(logicalcluster.New(*logicalClusterTarget)), resyncPeriod)
+	// New("root:default")
 	clusterWorkspaceController, err := clusterworkspace.NewController(&clusterworkspace.ControllerConfig{
 		OrgClient:             kcpOrgClient,
 		SharedInformerFactory: kcpOrgInformerFactory,

--- a/pkg/reconciler/clusterworkspace/clusterworkspace.go
+++ b/pkg/reconciler/clusterworkspace/clusterworkspace.go
@@ -1,0 +1,37 @@
+package clusterworkspace
+
+import (
+	"context"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	sandboxInitializer = "initializers.kuadarant.dev/workspace-sandbox"
+)
+
+// this controller watches the control cluster and mirrors cert secrets into the KCP cluster
+func (c *Controller) reconcile(ctx context.Context, clusterWorkspace *tenancyv1alpha1.ClusterWorkspace) error {
+
+	klog.Infof("reconciling clusterworkspace %s", clusterWorkspace.Name)
+
+	hasInitializer := false
+	for _, initializer := range clusterWorkspace.Status.Initializers {
+		if initializer == sandboxInitializer {
+			hasInitializer = true
+		}
+	}
+
+	if hasInitializer {
+		// TODO do something
+
+		// remove initializer
+		clusterWorkspace.Status.Initializers = make([]tenancyv1alpha1.ClusterWorkspaceInitializer, 0)
+		c.orgClient.Cluster(logicalcluster.From(clusterWorkspace)).TenancyV1alpha1().ClusterWorkspaces().UpdateStatus(ctx, clusterWorkspace, metav1.UpdateOptions{})
+
+	}
+	return nil
+}

--- a/pkg/reconciler/clusterworkspace/clusterworkspace.go
+++ b/pkg/reconciler/clusterworkspace/clusterworkspace.go
@@ -2,36 +2,143 @@ package clusterworkspace
 
 import (
 	"context"
+	"errors"
+
+	"github.com/kuadrant/kcp-glbc/pkg/util/metadata"
 
 	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
+	kcpapiv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
 const (
-	sandboxInitializer = "initializers.kuadarant.dev/workspace-sandbox"
+	glbcWorkspaceInitializer = "initializers.kuadarant.dev/workspace-sandbox"
+	glbcAPIExportName        = "glbc"
+	exportResourceAnnotation = "kuadrant.dev/export.resource"
 )
 
 // this controller watches the control cluster and mirrors cert secrets into the KCP cluster
 func (c *Controller) reconcile(ctx context.Context, clusterWorkspace *tenancyv1alpha1.ClusterWorkspace) error {
 
-	klog.Infof("reconciling clusterworkspace %s", clusterWorkspace.Name)
+	klog.Infof("reconciling %s workspace", clusterWorkspace.Name)
 
-	hasInitializer := false
-	for _, initializer := range clusterWorkspace.Status.Initializers {
-		if initializer == sandboxInitializer {
-			hasInitializer = true
+	if hasInitializers(clusterWorkspace) {
+		// To export resources into a workspace via the api binding, the workspace
+		// needs to have a status ready therefore we are adding an annotation to flag that
+		// an apibinding object needs to be created.
+		metadata.AddAnnotation(clusterWorkspace, exportResourceAnnotation, "true")
+		_, err := c.orgClient.Cluster(logicalcluster.From(clusterWorkspace)).
+			TenancyV1alpha1().
+			ClusterWorkspaces().
+			Update(ctx, clusterWorkspace, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		// remove initializer
+		klog.Infof("removing %s workspace initializer", clusterWorkspace.Name)
+		removeInitializers(clusterWorkspace)
+		_, err = c.orgClient.Cluster(logicalcluster.From(clusterWorkspace)).
+			TenancyV1alpha1().
+			ClusterWorkspaces().
+			UpdateStatus(ctx, clusterWorkspace, metav1.UpdateOptions{})
+		if err != nil {
+			return err
 		}
 	}
 
-	if hasInitializer {
-		// TODO do something
+	// verify if resources need to be exported to the new workspace
+	if _, ok := clusterWorkspace.Annotations[exportResourceAnnotation]; ok {
 
-		// remove initializer
-		clusterWorkspace.Status.Initializers = make([]tenancyv1alpha1.ClusterWorkspaceInitializer, 0)
-		c.orgClient.Cluster(logicalcluster.From(clusterWorkspace)).TenancyV1alpha1().ClusterWorkspaces().UpdateStatus(ctx, clusterWorkspace, metav1.UpdateOptions{})
+		ws, err := c.orgClient.Cluster(logicalcluster.From(clusterWorkspace)).
+			TenancyV1alpha1().
+			ClusterWorkspaces().
+			Get(ctx, clusterWorkspace.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 
+		// verify if workspace status is ready
+		if ws.Status.Phase != tenancyv1alpha1.ClusterWorkspacePhaseReady {
+			return errors.New("workspace is not ready, try again")
+		}
+
+		// export the glbc crds
+		klog.Infof("exporting glbc resources to %s workspace", clusterWorkspace.Name)
+		if err := c.reconcileAPIExportToNewWorkspace(ctx, ws); err != nil {
+			return err
+		}
+
+		// remove annotation
+		metadata.RemoveAnnotation(ws, exportResourceAnnotation)
+		_, err = c.orgClient.Cluster(logicalcluster.From(clusterWorkspace)).
+			TenancyV1alpha1().
+			ClusterWorkspaces().
+			Update(ctx, ws, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
 	}
+
 	return nil
+}
+
+func (c *Controller) reconcileAPIExportToNewWorkspace(ctx context.Context, newWorkspace *tenancyv1alpha1.ClusterWorkspace) error {
+
+	// get api export from the loadbalancer workspace
+	glbcWorkspacePath := "root:default:kcp-glbc"
+	glbcAPIExpoter, err := c.orgClient.Cluster(logicalcluster.New(glbcWorkspacePath)).
+		ApisV1alpha1().
+		APIExports().
+		Get(ctx, glbcAPIExportName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Found apiexport %s, now will create apibinding into new workspace", glbcAPIExpoter.Name)
+	glbcApiBinding := kcpapiv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: newWorkspace.GetName(),
+		},
+		Spec: kcpapiv1alpha1.APIBindingSpec{
+			Reference: kcpapiv1alpha1.ExportReference{
+				Workspace: &kcpapiv1alpha1.WorkspaceExportReference{
+					WorkspaceName: "kcp-glbc",
+					ExportName:    glbcAPIExpoter.Name,
+				},
+			},
+		},
+	}
+	_, err = c.orgClient.Cluster(logicalcluster.From(newWorkspace).Join(newWorkspace.Name)).ApisV1alpha1().
+		APIBindings().Create(ctx, &glbcApiBinding, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("apibinding %s created into new workspace %s", glbcApiBinding.Name, newWorkspace.Name)
+	return nil
+}
+
+func removeInitializers(clusterWorkspace *tenancyv1alpha1.ClusterWorkspace) {
+	newInitializers := make([]tenancyv1alpha1.ClusterWorkspaceInitializer, 0, len(clusterWorkspace.Status.Initializers))
+	for _, i := range clusterWorkspace.Status.Initializers {
+		if i != glbcWorkspaceInitializer {
+			newInitializers = append(newInitializers, i)
+		}
+	}
+	clusterWorkspace.Status.Initializers = newInitializers
+}
+
+func hasInitializers(clusterWorkspace *tenancyv1alpha1.ClusterWorkspace) bool {
+	initializers := clusterWorkspace.Status.Initializers
+	for _, initializer := range initializers {
+		if initializer == glbcWorkspaceInitializer {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/reconciler/clusterworkspace/controller.go
+++ b/pkg/reconciler/clusterworkspace/controller.go
@@ -1,0 +1,147 @@
+package clusterworkspace
+
+import (
+	"context"
+	"time"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	tenancyv1alpha1lister "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+const controllerName = "kcp-glbc-bootstrap"
+
+// NewController returns a new Controller which reconciles resources at workspace levels.
+
+func NewController(config *ControllerConfig) (*Controller, error) {
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	c := &Controller{
+		queue:                 queue,
+		orgClient:             config.OrgClient,
+		sharedInformerFactory: config.SharedInformerFactory,
+	}
+
+	c.sharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueue(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueue(obj) },
+		DeleteFunc: func(obj interface{}) { c.enqueue(obj) },
+	})
+
+	c.indexer = c.sharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Informer().GetIndexer()
+	c.lister = c.sharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Lister()
+	return c, nil
+}
+
+type ControllerConfig struct {
+	OrgClient             clientset.ClusterInterface
+	SharedInformerFactory informers.SharedInformerFactory
+}
+
+type Controller struct {
+	queue                 workqueue.RateLimitingInterface
+	sharedInformerFactory informers.SharedInformerFactory
+	indexer               cache.Indexer
+	lister                tenancyv1alpha1lister.ClusterWorkspaceLister
+	orgClient             clientset.ClusterInterface
+}
+
+func (c *Controller) enqueue(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	c.queue.AddRateLimited(key)
+}
+
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.InfoS("Starting workers", "controller", controllerName)
+	defer klog.InfoS("Stopping workers", "controller", controllerName)
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+func (c *Controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	err := c.process(ctx, key)
+	c.handleErr(err, key)
+	return true
+}
+
+func (c *Controller) handleErr(err error, key string) {
+	// Reconcile worked, nothing else to do for this workqueue item.
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	// Re-enqueue up to 5 times.
+	num := c.queue.NumRequeues(key)
+	if num < 5 {
+		klog.Errorf("Error reconciling key %q, retrying... (#%d): %v", key, num, err)
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	// Give up and report error elsewhere.
+	c.queue.Forget(key)
+	runtime.HandleError(err)
+	klog.Infof("Dropping key %q after failed retries: %v", key, err)
+}
+
+func (c *Controller) process(ctx context.Context, key string) error {
+	obj, exists, err := c.indexer.GetByKey(key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		klog.Infof("Object with key %q was deleted", key)
+		return nil
+	}
+	current := obj.(*tenancyv1alpha1.ClusterWorkspace)
+
+	previous := current.DeepCopy()
+	if err := c.reconcile(ctx, current); err != nil {
+		return err
+	}
+	// If the object being reconciled changed as a result, update it.
+	if !equality.Semantic.DeepEqual(previous, current) {
+		_, err := c.orgClient.Cluster(logicalcluster.From(current)).TenancyV1alpha1().ClusterWorkspaces().Update(ctx, current, metav1.UpdateOptions{})
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds the ability to watch new workspaces with an initialiser `initializers.kuadarant.dev/workspace-sandbox` to enable the creation of resources at bootstrap of a new workspace. We are using the APIBinding and APIExport objects to export the resources from the glbc workspace into other workspaces.


## Verification steps

1. Install the load balancer from this PR 
```
make local-setup
````
2. Start the kcp-ingress
```
./bin/kcp-glbc --kubeconfig .kcp/admin.kubeconfig --context system:admin --glbc-kubeconfig ./tmp/kcp-cluster-glbc-control.kubeconfig
```
3. Navigate to the organisation Workspace 
```
./bin/kubectl-kcp workspace ..
```
4. Patch the universal workspace type to add the initializer 
```
kubectl patch clusterworkspacetype universal --type json -p='[{"op": "add", "path": "/spec/initializers/-","value":initializers.kuadarant.dev/workspace-sandbox}]'`
```
5. Create a new workspace 
```
./bin/kubectl-kcp workspace create mybox
```
6. Verify if the workspace has the status changed to ready 
```
kubectl get workspace mybox -o yaml 
```
7. Navigate to the new workspace 
```
./bin/kubectl-kcp workspace use mybox
```
8. Verify the status of the apibinding 
```
kubectl get apibinding mybox -o yaml
```
9. Check if the dnsrecord resource was created into the new workspace 
```
kubectl get dnsrecord
```
