### PR TITLE
Remove kcp.dev/placement annotation from sample

### DIFF
--- a/samples/echo-service/echo.yaml
+++ b/samples/echo-service/echo.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: httpecho-both
-  annotations:
-    kcp.dev/placement: kcp-cluster-1,kcp-cluster-2
 spec:
   ports:
     - name: http-port


### PR DESCRIPTION
The kcp-glbc placement code is being removed in favour of the kcp
placement logic. Removing this so it doesn't interfere in the meantime.

Related to https://github.com/Kuadrant/kcp-glbc/pull/74