### PR TITLE
Co-locate cert-manager resources in kcp-glbc namespace

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,11 @@ spec:
           name: manager
           securityContext:
             allowPrivilegeEscalation: false
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - secretRef:
                 name: aws-credentials

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  creationTimestamp: null
-  name: kcp-glbc-manager-role
+  name: kcp-glbc-controller-manager
 rules:
   - apiGroups:
       - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,12 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: kcp-glbc-manager-rolebinding
+  name: kcp-glbc-controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kcp-glbc-manager-role
+  kind: Role
+  name: kcp-glbc-controller-manager
 subjects:
   - kind: ServiceAccount
     name: kcp-glbc-controller-manager
-    namespace: system

--- a/pkg/reconciler/tls/secrets.go
+++ b/pkg/reconciler/tls/secrets.go
@@ -77,7 +77,7 @@ func AddFinalizer(secret *v1.Secret, finalizer string) {
 }
 
 func (c *Controller) ensureDelete(ctx context.Context, kctx cluster.ObjectMapper, secret *v1.Secret) error {
-	if err := c.kcpClient.Cluster(logicalcluster.New(kctx.Workspace())).CoreV1().Secrets(kctx.Namespace()).Delete(ctx, kctx.Name(), metav1.DeleteOptions{}); err != nil && !k8errors.IsNotFound(err) {
+	if err := c.kcpKubeClient.Cluster(logicalcluster.New(kctx.Workspace())).CoreV1().Secrets(kctx.Namespace()).Delete(ctx, kctx.Name(), metav1.DeleteOptions{}); err != nil && !k8errors.IsNotFound(err) {
 		return err
 	}
 	return nil
@@ -94,8 +94,8 @@ func (c *Controller) ensureMirrored(ctx context.Context, kctx cluster.ObjectMapp
 		Data: secret.Data,
 		Type: secret.Type,
 	}
-	secretClient := c.kcpClient.Cluster(logicalcluster.New(kctx.Workspace())).CoreV1().Secrets(kctx.Namespace())
-	// using kcpClient here to target the KCP cluster
+	// using the KCP client here to target the KCP cluster
+	secretClient := c.kcpKubeClient.Cluster(logicalcluster.New(kctx.Workspace())).CoreV1().Secrets(kctx.Namespace())
 	_, err := secretClient.Create(ctx, mirror, metav1.CreateOptions{})
 	if err != nil {
 		if !k8errors.IsAlreadyExists(err) {
@@ -112,7 +112,7 @@ func (c *Controller) ensureMirrored(ctx context.Context, kctx cluster.ObjectMapp
 		}
 	}
 	// find the Ingress this Secret is for and add an annotation to notify TLS certificate is ready and trigger reconcile
-	ingressClient := c.kcpClient.Cluster(logicalcluster.New(kctx.Workspace())).NetworkingV1().Ingresses(kctx.Namespace())
+	ingressClient := c.kcpKubeClient.Cluster(logicalcluster.New(kctx.Workspace())).NetworkingV1().Ingresses(kctx.Namespace())
 	rootIngress, err := ingressClient.Get(ctx, kctx.OwnedBy(), metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/pkg/tls/cert_manager.go
+++ b/pkg/tls/cert_manager.go
@@ -36,7 +36,8 @@ import (
 type DNSValidator int
 
 const (
-	DNSValidatorRoute53 DNSValidator = iota
+	DNSValidatorRoute53  DNSValidator = iota
+	DefaultCertificateNS string       = "cert-manager"
 )
 
 type CertProvider string
@@ -51,7 +52,6 @@ const (
 	CertProviderLEProd    CertProvider = "letsencryptprod"
 	leProdAPI             string       = "https://acme-v02.api.letsencrypt.org/directory"
 	leStagingAPI          string       = "https://acme-staging-v02.api.letsencrypt.org/directory"
-	defaultCertificateNS  string       = "cert-manager"
 )
 
 // CertManager is a certificate provider.
@@ -113,6 +113,7 @@ func NewCertManager(c CertManagerConfig) (*CertManager, error) {
 		certProvider:          c.CertProvider,
 		Region:                c.Region,
 		validDomains:          c.ValidDomains,
+		certificateNS:         c.CertificateNS,
 	}
 
 	if c.LEConfig == nil {
@@ -126,9 +127,6 @@ func NewCertManager(c CertManagerConfig) (*CertManager, error) {
 		return nil, fmt.Errorf("certmanager: missing env var %s", envLEEmail)
 	}
 
-	if cm.certificateNS == "" {
-		cm.certificateNS = defaultCertificateNS
-	}
 	return cm, nil
 }
 

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 )
 
+const namespaceEnvVariable = "NAMESPACE"
+
 func GetEnvString(key, fallback string) string {
 	value, found := os.LookupEnv(key)
 	if !found {
@@ -23,4 +25,8 @@ func GetEnvBool(key string, fallback bool) bool {
 		return fallback
 	}
 	return value
+}
+
+func GetNamespace() string {
+	return GetEnvString(namespaceEnvVariable, "")
 }


### PR DESCRIPTION
Fixes #102.

It relies on the Downward API to retrieve the Deployment namespace. It also skips starting the informer that watches for TLS Secrets, when TLS certificate is disabled, to avoid the work-queue to keep growing, as items are not consumed.

Incidentally, this enables changing the current ClusterRole for a Role, to avoid RW cluster-wide permissions for Secrets and Certificates, that may be considered too broad to meet some security models.