### PR TITLE
Grafana installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,6 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 LD_DIR=config/deploy/local
 LD_AWS_CREDS_ENV=$(LD_DIR)/aws-credentials.env
 LD_CONTROLLER_CONFIG_ENV=$(LD_DIR)/controller-config.env
-LD_GLBC_KUBECONFIG=$(LD_DIR)/glbc.kubeconfig
 LD_KCP_KUBECONFIG=$(LD_DIR)/kcp.kubeconfig
 
 $(LD_AWS_CREDS_ENV):
@@ -124,14 +123,11 @@ $(LD_CONTROLLER_CONFIG_ENV):
 		< $(LD_CONTROLLER_CONFIG_ENV).template \
 		> $(LD_CONTROLLER_CONFIG_ENV)
 
-$(LD_GLBC_KUBECONFIG):
-	cp ./tmp/kcp-cluster-glbc-control.kubeconfig.internal $(LD_GLBC_KUBECONFIG)
-
 $(LD_KCP_KUBECONFIG):
 	cp .kcp/admin.kubeconfig $(LD_KCP_KUBECONFIG)
 
 .PHONY: generate-ld-config
-generate-ld-config: $(LD_AWS_CREDS_ENV) $(LD_CONTROLLER_CONFIG_ENV) $(LD_GLBC_KUBECONFIG) $(LD_KCP_KUBECONFIG) ## Generate local deployment files.
+generate-ld-config: $(LD_AWS_CREDS_ENV) $(LD_CONTROLLER_CONFIG_ENV) $(LD_KCP_KUBECONFIG) ## Generate local deployment files.
 
 .PHONY: clean-ld-env
 clean-ld-env:
@@ -140,7 +136,6 @@ clean-ld-env:
 
 .PHONY: clean-ld-kubeconfig
 clean-ld-kubeconfig:
-	-rm -f $(LD_GLBC_KUBECONFIG)
 	-rm -f $(LD_KCP_KUBECONFIG)
 
 .PHONY: clean-ld-config
@@ -152,7 +147,7 @@ ifeq ($(DO_BREW),true)
 endif
 
 .PHONY: local-setup
-local-setup: clean kind kcp build ## Setup kcp locally using kind.
+local-setup: clean kind kcp kustomize build ## Setup kcp locally using kind.
 	./utils/local-setup.sh -c ${NUM_CLUSTERS} ${LOCAL_SETUP_FLAGS}
 
 ##@ Build Dependencies

--- a/config/deploy/local/kustomization.yaml
+++ b/config/deploy/local/kustomization.yaml
@@ -4,7 +4,6 @@
 # controller-config.env
 # aws-credentials.env
 # kcp.kubeconfig
-# glbc.kubeconfig
 #
 # These can be generated using `make generate-ld-config` and then modified as required.
 # `make generate-ld-config` creates configuration for the local dev environment so you must have ran `make local-setup` first.
@@ -26,10 +25,6 @@ secretGenerator:
     behavior: replace
     files:
       - kubeconfig=kcp.kubeconfig
-  - name: glbc-kubeconfig
-    behavior: replace
-    files:
-      - kubeconfig=glbc.kubeconfig
   - name: aws-credentials
     behavior: replace
     envs:

--- a/config/grafana/auth-proxy/cluster_role.yaml
+++ b/config/grafana/auth-proxy/cluster_role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: system
+  name: grafana-proxy
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+  - verbs:
+      - create
+    apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews

--- a/config/grafana/auth-proxy/cluster_role_binding.yaml
+++ b/config/grafana/auth-proxy/cluster_role_binding.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-cluster-monitoring-binding
+subjects:
+  - kind: ServiceAccount
+    namespace: system
+    name: grafana-serviceaccount
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  namespace: system
+  name: grafana-proxy
+roleRef:
+  kind: ClusterRole
+  name: grafana-proxy
+subjects:
+  - kind: ServiceAccount
+    name: grafana-serviceaccount
+    namespace: system

--- a/config/grafana/auth-proxy/grafana.yaml
+++ b/config/grafana/auth-proxy/grafana.yaml
@@ -1,0 +1,83 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: grafana
+spec:
+  config:
+    log:
+      mode: "console"
+      level: "warn"
+    auth.anonymous:
+      enabled: False
+    auth:
+      disable_login_form: True
+      disable_signout_menu: True
+    auth.basic:
+      enabled: False
+    auth.proxy:
+      enabled: True
+      enable_login_token: True
+      header_property: username
+      header_name: X-Forwarded-User
+    users:
+      viewers_can_edit: True
+      auto_assign_org_role: Admin
+  dashboardLabelSelector:
+    - matchExpressions:
+        - { key: app, operator: In, values: [ grafana ] }
+  containers:
+    - args:
+        - '-provider=openshift'
+        - '-pass-basic-auth=false'
+        - '-https-address=:9091'
+        - '-http-address='
+        - '-email-domain=*'
+        - '-upstream=http://localhost:3000'
+        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+        - '-tls-cert=/etc/tls/private/tls.crt'
+        - '-tls-key=/etc/tls/private/tls.key'
+        - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
+        - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
+        - '-openshift-service-account=grafana-serviceaccount'
+        - '-openshift-ca=/etc/pki/tls/cert.pem'
+        - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        - '-openshift-ca=/etc/grafana-configmaps/ocp-injected-certs/ca-bundle.crt'
+        - '-skip-auth-regex=^/metrics'
+      image: 'quay.io/openshift/origin-oauth-proxy'
+      name: grafana-proxy
+      ports:
+        - containerPort: 9091
+          name: https
+      resources: {}
+      volumeMounts:
+        - mountPath: /etc/tls/private
+          name: secret-grafana-tls
+          readOnly: false
+        - mountPath: /etc/proxy/secrets
+          name: secret-grafana-proxy
+          readOnly: false
+  secrets:
+    - grafana-tls
+    - grafana-proxy
+  configMaps:
+    - ocp-injected-certs
+  service:
+    ports:
+      - name: https
+        port: 9091
+        protocol: TCP
+        targetPort: https
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: grafana-tls
+  ingress:
+    enabled: False
+  client:
+    preferService: True
+  serviceAccount:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'
+  resources:
+    requests:
+      cpu: 4m
+      memory: 64Mi

--- a/config/grafana/auth-proxy/grafana_route.yaml
+++ b/config/grafana/auth-proxy/grafana_route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: grafana
+  namespace: system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: grafana-tls
+spec:
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: grafana-service
+    weight: 100
+  wildcardPolicy: None

--- a/config/grafana/auth-proxy/kustomization.yaml
+++ b/config/grafana/auth-proxy/kustomization.yaml
@@ -1,0 +1,16 @@
+
+resources:
+  - service_account.yaml
+  - cluster_role.yaml
+  - cluster_role_binding.yaml
+  - ocp-injected-certs.yaml
+  - grafana_route.yaml
+  - grafana.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: grafana-proxy
+    literals:
+      - session_secret=CHANGEME

--- a/config/grafana/auth-proxy/ocp-injected-certs.yaml
+++ b/config/grafana/auth-proxy/ocp-injected-certs.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: ocp-injected-certs

--- a/config/grafana/auth-proxy/service_account.yaml
+++ b/config/grafana/auth-proxy/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-serviceaccount
+  namespace: system

--- a/config/grafana/grafana.yaml
+++ b/config/grafana/grafana.yaml
@@ -1,0 +1,37 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: grafana
+spec:
+  client:
+    preferService: true
+  ingress:
+    enabled: True
+    pathType: Prefix
+    path: "/"
+  config:
+    log:
+      mode: "console"
+      level: "error"
+    log.frontend:
+      enabled: true
+    auth:
+      disable_login_form: False
+      disable_signout_menu: True
+    auth.anonymous:
+      enabled: True
+    security:
+      admin_user: "admin"
+      admin_password: "admin"
+  service:
+    name: "grafana-service"
+    labels:
+      app: "grafana"
+      type: "grafana-service"
+  dashboardLabelSelector:
+    - matchExpressions:
+        - { key: app, operator: In, values: [grafana] }
+  resources:
+    requests:
+      cpu: 4m
+      memory: 64Mi

--- a/config/grafana/kustomization.yaml
+++ b/config/grafana/kustomization.yaml
@@ -1,0 +1,3 @@
+
+resources:
+  - grafana.yaml

--- a/config/grafana/operator/kustomization.yaml
+++ b/config/grafana/operator/kustomization.yaml
@@ -1,0 +1,7 @@
+#https://github.com/grafana-operator/grafana-operator/blob/master/documentation/deploy_grafana.md
+
+resources:
+  - github.com/grafana-operator/grafana-operator/deploy/manifests?ref=v4.2.0
+
+patchesStrategicMerge:
+  - security_context.yaml

--- a/config/grafana/operator/security_context.yaml
+++ b/config/grafana/operator/security_context.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      securityContext:
+        $patch: replace
+        runAsNonRoot: true

--- a/config/manager/config/kustomization.yaml
+++ b/config/manager/config/kustomization.yaml
@@ -9,5 +9,4 @@ configMapGenerator:
 
 secretGenerator:
 - name: kcp-kubeconfig
-- name: glbc-kubeconfig
 - name: aws-credentials

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,6 @@ spec:
             - /kcp-glbc
           args:
             - --kubeconfig=/tmp/kcp/kubeconfig
-            - --glbc-kubeconfig=/tmp/glbc/kubeconfig
           image: controller:latest
           name: manager
           securityContext:
@@ -60,17 +59,10 @@ spec:
             - name: kcp-kubeconfig
               mountPath: "/tmp/kcp"
               readOnly: true
-            - name: glbc-kubeconfig
-              mountPath: "/tmp/glbc"
-              readOnly: true
       serviceAccountName: kcp-glbc-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: kcp-kubeconfig
           secret:
             secretName: kcp-kubeconfig
-            optional: false
-        - name: glbc-kubeconfig
-          secret:
-            secretName: glbc-kubeconfig
             optional: false

--- a/config/observability/kubernetes/grafana/ingress.yaml
+++ b/config/observability/kubernetes/grafana/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-grafana
+spec:
+  rules:
+    - host: grafana.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana-service
+                port:
+                  number: 3000

--- a/config/observability/kubernetes/grafana/kustomization.yaml
+++ b/config/observability/kubernetes/grafana/kustomization.yaml
@@ -1,0 +1,8 @@
+## Adds namespace to all resources.
+namespace: kcp-glbc-observability
+
+resources:
+  - ../../../grafana/operator
+  - ../../../grafana
+  - ingress.yaml
+  - prometheus-grafanadatasource.yaml

--- a/config/observability/kubernetes/grafana/prometheus-grafanadatasource.yaml
+++ b/config/observability/kubernetes/grafana/prometheus-grafanadatasource.yaml
@@ -1,0 +1,13 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: prometheus-grafanadatasource
+spec:
+  name: prometheus-grafanadatasource.yaml
+  datasources:
+    - name: Prometheus
+      type: prometheus
+      url: 'http://prometheus-k8s.monitoring.svc:9090'
+      access: proxy
+      editable: true
+      isDefault: true

--- a/config/observability/kubernetes/kustomization.yaml
+++ b/config/observability/kubernetes/kustomization.yaml
@@ -1,0 +1,4 @@
+
+resources:
+  - prometheus
+  - grafana

--- a/config/observability/kubernetes/prometheus/ingress.yaml
+++ b/config/observability/kubernetes/prometheus/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-prometheus
+  namespace: monitoring
+spec:
+  rules:
+    - host: prometheus.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus-k8s
+                port:
+                  number: 9090

--- a/config/observability/kubernetes/prometheus/kustomization.yaml
+++ b/config/observability/kubernetes/prometheus/kustomization.yaml
@@ -1,0 +1,4 @@
+
+resources:
+  - ../../../prometheus/operator
+  - ingress.yaml

--- a/config/observability/openshift/grafana/cluster-monitoring-config.yaml
+++ b/config/observability/openshift/grafana/cluster-monitoring-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/config/observability/openshift/grafana/kustomization.yaml
+++ b/config/observability/openshift/grafana/kustomization.yaml
@@ -1,0 +1,7 @@
+## Adds namespace to all resources.
+namespace: kcp-glbc-observability
+
+resources:
+  - ../../../grafana/operator
+  - ../../../grafana/auth-proxy
+  - prometheus-grafanadatasource.yaml

--- a/config/observability/openshift/grafana/prometheus-grafanadatasource.yaml
+++ b/config/observability/openshift/grafana/prometheus-grafanadatasource.yaml
@@ -1,0 +1,19 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: prometheus-grafanadatasource
+spec:
+  name: prometheus-grafanadatasource.yaml
+  datasources:
+    - name: Prometheus
+      type: prometheus
+      url: 'https://thanos-querier.openshift-monitoring.svc:9091'
+      access: proxy
+      editable: true
+      isDefault: true
+      jsonData:
+        httpHeaderName1: 'Authorization'
+        timeInterval: 5s
+        tlsSkipVerify: true
+      secureJsonData:
+        httpHeaderValue1: 'Bearer CHANGEME'

--- a/config/observability/openshift/kustomization.yaml
+++ b/config/observability/openshift/kustomization.yaml
@@ -1,0 +1,3 @@
+
+resources:
+  - grafana

--- a/config/prometheus/operator/cluster_role.yaml
+++ b/config/prometheus/operator/cluster_role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/prometheus/operator/kustomization.yaml
+++ b/config/prometheus/operator/kustomization.yaml
@@ -1,0 +1,7 @@
+# https://github.com/prometheus-operator/kube-prometheus/
+
+resources:
+  - github.com/prometheus-operator/kube-prometheus?ref=release-0.10
+
+patchesStrategicMerge:
+  - cluster_role.yaml

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,7 +71,6 @@ $ tree -I '*.yaml|*.template' config/deploy/local/
 config/deploy/local/
 ├── aws-credentials.env
 ├── controller-config.env
-├── glbc.kubeconfig
 └── kcp.kubeconfig
 ```
 
@@ -96,15 +95,6 @@ during installation, but can be replaced with:
 
 ```
 kubectl -n kcp-glbc create secret generic kcp-glbc-kcp-kubeconfig --from-file=kubeconfig=$(KCP_KUBECONFIG)
-```
-
-### GLBC Control Cluster Kubeconfig (Required)
-
-A secret `secret/kcp-glbc-glbc-kubeconfig` containing the GLBC control clusters kubeconfig. This is the cluster running cert manager. 
-An empty secret is created by default during installation, but can be replaced with:
-
-```
-kubectl -n kcp-glbc create secret generic kcp-glbc-glbc-kubeconfig --from-file=kubeconfig=$(GLBC_KUBECONFIG)
 ```
 
 ### AWS Credentials (Optional) 

--- a/docs/observability/grafana.adoc
+++ b/docs/observability/grafana.adoc
@@ -1,0 +1,72 @@
+[[grafana]]
+= Grafana
+
+The https://github.com/grafana-operator/grafana-operator[Grafana operator] is used to install and configure grafana as part of the KCP GLBC monitoring stack.
+
+[[prerequisites]]
+== Prerequisites
+
+Prometheus instance, configured to integrate with the KCP GLBC instance deployed on the same cluster, see link:monitoring.adoc[monitoring].
+
+[[kubernetes]]
+=== Kubernetes
+
+Installations on Kubernetes require a prometheus instance deployed and configured on the target cluster.
+The following will install the https://github.com/prometheus-operator/kube-prometheus[kube-prometheus monitoring stack] as part of the installation.
+Note, only prometheus is required, please refer to the link:monitoring.adoc[monitoring] guide for other installation options.
+
+Deploy prometheus and grafana
+[source,console]
+----
+$ ./bin/kustomize build config/observability/kubernetes/ | kubectl apply -f -
+----
+Note: You might need to do this a couple of times.
+
+// Check Grafana
+$ kubectl get deployments -n kcp-glbc-observability
+NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
+grafana-deployment                    1/1     1            1           54s
+grafana-operator-controller-manager   1/1     1            1           2m14s
+
+If testing on a https://kind.sigs.k8s.io//[kind] cluster, the console should be accessible from http://grafana.127.0.0.1.nip.io:<node port> (user:admin, password: admin)
+
+
+[[openshift]]
+=== OpenShift
+
+Installations on OpenShift make use of the pre-configured https://docs.openshift.com/container-platform/4.10/monitoring/monitoring-overview.html[monitoring stack] and expect https://docs.openshift.com/container-platform/4.10/monitoring/enabling-monitoring-for-user-defined-projects.html[user workload monitoring] to be enabled.
+
+Extract a token to connect to the user workload prometheus:
+[source,console]
+----
+$ SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
+$ TOKEN=`echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d`
+----
+
+Update grafana prometheus data source with the token extracted above:
+[source,console]
+----
+$ sed -i "s/CHANGEME/$TOKEN/" config/observability/openshift/grafana/prometheus-grafanadatasource.yaml
+----
+
+Deploy grafana
+[source,console]
+----
+$ ./bin/kustomize build config/observability/openshift/ | kubectl apply -f -
+----
+Note: You might need to do this a couple of times.
+
+// Check Grafana
+[source,console]
+----
+$ kubectl get deployments -n kcp-glbc-observability
+NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
+grafana-deployment                    1/1     1            1           54s
+grafana-operator-controller-manager   1/1     1            1           2m14s
+$ kubectl get routes -n kcp-glbc-observability
+NAME      HOST/PORT                                         PATH   SERVICES          PORT    TERMINATION   WILDCARD
+grafana   grafana-kcp-glbc-observability.apps-crc.testing          grafana-service   https   reencrypt     None
+----
+
+If testing on a https://crc.dev/crc/[crc] cluster, the console should be accesible from https://grafana-kcp-glbc-observability.apps-crc.testing (OpenShift login user: kubadmin)
+

--- a/utils/local-setup.sh
+++ b/utils/local-setup.sh
@@ -61,6 +61,7 @@ export GOROOT
 export KIND_BIN="./bin/kind"
 export KCP_BIN="./bin/kcp"
 export KUBECTL_KCP_BIN="./bin/kubectl-kcp"
+export KUSTOMIZE_BIN="./bin/kustomize"
 TEMP_DIR="./tmp"
 KCP_LOG_FILE="${TEMP_DIR}"/kcp.log
 
@@ -74,17 +75,6 @@ do
 done
 
 mkdir -p ${TEMP_DIR}
-
-createGLBCCluster() {
-  ${KIND_BIN} create cluster --name ${KCP_GLBC_CLUSTER_NAME}
-  ${KIND_BIN} get kubeconfig --name=${KCP_GLBC_CLUSTER_NAME} > ${TEMP_DIR}/${KCP_GLBC_KUBECONFIG}
-  ${KIND_BIN} get kubeconfig --internal --name=${KCP_GLBC_CLUSTER_NAME} > ${TEMP_DIR}/${KCP_GLBC_KUBECONFIG}.internal
-
-  echo "Deploying cert manager to kind glbc cluster"
-  kubectl --context kind-${KCP_GLBC_CLUSTER_NAME} apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
-
-  kubectl --context kind-${KCP_GLBC_CLUSTER_NAME} -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
-}
 
 createCluster() {
   cluster=$1;
@@ -128,15 +118,21 @@ EOF
   } &>/dev/null
 }
 
+createGLBCCluster() {
+  createCluster "$KCP_GLBC_CLUSTER_NAME" $1 $2
+
+  kubectl config use-context kind-${KCP_GLBC_CLUSTER_NAME}
+
+  echo "Deploying cert manager to kind glbc cluster"
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
+  kubectl -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
+}
+
 clusterCount=$(${KIND_BIN} get clusters | grep ${KIND_CLUSTER_PREFIX} | wc -l)
 if ! [[ $clusterCount =~ "0" ]] ; then
   echo "Deleting previous kind clusters."
   ${KIND_BIN} get clusters | grep ${KIND_CLUSTER_PREFIX} | xargs ${KIND_BIN} delete clusters
 fi
-
-echo "Deploying 1 kind k8s glbc cluster locally."
-
-createGLBCCluster
 
 echo "Deploying $NUM_CLUSTERS kind k8s clusters locally."
 
@@ -149,6 +145,10 @@ do
   port443=$((port443+1))
 #move to next cluster
 done
+
+echo "Deploying 1 kind k8s glbc cluster locally."
+
+createGLBCCluster $port80 $port443
 
 echo "Starting KCP, sending logs to ${KCP_LOG_FILE}"
 ${KCP_BIN} start --push-mode --discovery-poll-interval 3s --run-controllers --resources-to-sync=secrets,deployments,services,ingresses.networking.k8s.io --auto-publish-apis > ${KCP_LOG_FILE} 2>&1 &
@@ -170,13 +170,16 @@ export KUBECONFIG=.kcp/admin.kubeconfig
 echo "Creating HCG Workspace"
 ${KUBECTL_KCP_BIN} workspace create kcp-glbc --enter
 
+echo "Waiting 15 seconds..."
+sleep 15
+
 echo "Registering HCG APIs"
 kubectl apply -f ./config/crd/bases
 kubectl apply -f ./utils/kcp-contrib/apiresourceschema.yaml
 kubectl apply -f ./utils/kcp-contrib/apiexport.yaml
 
 echo "Registering kind k8s clusters into KCP"
-kubectl apply $(find ./tmp/kcp-cluster-*.yaml | awk ' { print " -f " $1 } ')
+kubectl apply $(find ./tmp/ -name 'kcp-cluster-[[:digit:]]*.yaml' | awk ' { print " -f " $1 } ')
 
 echo ""
 echo "KCP PID          : ${KCP_PID}"


### PR DESCRIPTION
Add observability kustomization

Adds kustomization files to install the observability stack for kcp-glbc (prometheus and grafana). On OpenShift this relies on the pre-configured monitoring stack using user workload monitoring and installs grafana only with an auth proxy for OpenShift login. On k8s clusters, it installs the kube-prometheus stack (prometheus) and grafana with basic login.

Remove arg from deployment (--glbc-kubeconfig=/tmp/glbc/kubeconfig). The default behaviour now expects the kcp glbc to be running on the same cluster as cert-manager etc..

Update local-setup-add-crc-cluster (Enable cluster monitoring)
Update local-setup script so that the glbc cluster has the ingress controller installed.

**Verification**

Terminal 1 (Run KCP)
```
make local-setup
```

Terminal 2 (OpenShift CRC)
```
//Create crc vm with monitoring enabled
$ ./utils/local-setup-add-crc-cluster.sh

//Deploy kcp-glbc
$ kubectl config use-context crc-admin
$ make deploy

//Deploy Observability stack (Grafana)
$ SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
$ TOKEN=`echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d`
$ sed -i "s/CHANGEME/$TOKEN/" config/observability/openshift/grafana/prometheus-grafanadatasource.yaml
$ ./bin/kustomize build config/observability/openshift/ | kubectl apply -f -
//Note: You might need to do this a couple of times

// Deploy Pod Monitor for kcp-glbc
$ ./bin/kustomize build config/prometheus/ | kubectl -n kcp-glbc apply -f -

// Check Prometheus
$ kubectl -n openshift-user-workload-monitoring get secret prometheus-user-workload -ojson | jq -r '.data["prometheus.yaml.gz"]' | base64 -d | gunzip | grep kcp-glbc
- job_name: podMonitor/kcp-glbc/kcp-glbc-controller-manager/0
      - kcp-glbc
    regex: kcp-glbc
    replacement: kcp-glbc/kcp-glbc-controller-manager
    replacement: kcp-glbc

// Check Grafana
$ kubectl get deployments -n kcp-glbc-observability
NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
grafana-deployment                    1/1     1            1           54s
grafana-operator-controller-manager   1/1     1            1           2m14s
$ kubectl get routes -n kcp-glbc-observability
NAME      HOST/PORT                                         PATH   SERVICES          PORT    TERMINATION   WILDCARD
grafana   grafana-kcp-glbc-observability.apps-crc.testing          grafana-service   https   reencrypt     None

Console should be accessible from https://grafana-kcp-glbc-observability.apps-crc.testing (OpenShift login user: kubadmin)
```
Terminal 2 (K8s kind)
```
// Deploy kcp-glbc
$ kubectl config use-context kind-kcp-cluster-glbc-control
$ make deploy

// Deploy Observability stack (Prometheus and Grafana)
$  ./bin/kustomize build config/observability/kubernetes/ | kubectl apply --force-conflicts  --server-side -f -
//Note: You might need to do this a couple of times

// Deploy Pod Monitor for kcp-glbc
./bin/kustomize build config/prometheus/ | kubectl -n kcp-glbc apply -f -

// Check Prometheus
$ kubectl -n monitoring get secret prometheus-k8s -o json | jq -r '.data["prometheus.yaml.gz"]'| base64 -d | gunzip | grep kcp-glbc
- job_name: podMonitor/kcp-glbc/kcp-glbc-controller-manager/0
      - kcp-glbc
    regex: (kcp-glbc);true
    replacement: kcp-glbc/kcp-glbc-controller-manager

$ docker ps --format '{{json .}}' | jq -e 'select(.Names == "kcp-cluster-glbc-control-control-plane").Ports'
"0.0.0.0:8083->80/tcp, 0.0.0.0:8446->443/tcp, 127.0.0.1:34661->6443/tcp"

$ curl -s http://prometheus.127.0.0.1.nip.io:8083/api/v1/targets | jq -e '.data.activeTargets[] | select(.labels.job == "kcp-glbc/kcp-glbc-controller-manager").labels'
{
  "container": "manager",
  "endpoint": "metrics",
  "instance": "10.244.0.11:8080",
  "job": "kcp-glbc/kcp-glbc-controller-manager",
  "namespace": "kcp-glbc",
  "pod": "kcp-glbc-controller-manager-5dcfb4748-hgv9t"
}

Console should be accessible from http://prometheus.127.0.0.1.nip.io:8083

// Check Grafana
$ kubectl get deployments -n kcp-glbc-observability
NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
grafana-deployment                    1/1     1            1           54s
grafana-operator-controller-manager   1/1     1            1           2m14s

Console should be accessible from http://grafana.127.0.0.1.nip.io:8083 (user:admin, password: admin)
```
