### PR TITLE
Structured logging

### DIFF
--- a/cmd/kcp-glbc/main.go
+++ b/cmd/kcp-glbc/main.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 
 	// Make sure our workqueue MetricsProvider is the first to register
@@ -88,7 +90,16 @@ func init() {
 	//  Observability options
 	flagSet.IntVar(&options.MonitoringPort, "monitoring-port", 8080, "The port of the metrics endpoint (can be set to \"0\" to disable the metrics serving)")
 
-	opts := log.Options{}
+	opts := log.Options{
+		EncoderConfigOptions: []log.EncoderConfigOption{
+			func(c *zapcore.EncoderConfig) {
+				c.ConsoleSeparator = " "
+			},
+		},
+		ZapOpts: []zap.Option{
+			zap.AddCaller(),
+		},
+	}
 	opts.BindFlags(flag.CommandLine)
 	klog.InitFlags(flag.CommandLine)
 	flag.Parse()

--- a/docs/observability/logging.adoc
+++ b/docs/observability/logging.adoc
@@ -1,0 +1,50 @@
+[[logging]]
+= KCP GLBC Logging
+
+The KCP GLBC uses https://pkg.go.dev/github.com/go-logr/logr[logr] as logging interface, and relies on https://pkg.go.dev/go.uber.org/zap[Zap] as logging backend.
+
+It binds Zap configuration to the CLI options, so that it's possible to set logging output either to `console` or `json`, e.g., with the `json` output:
+
+[source,console]
+----
+$ kcp-glbc --zap-encoder=json
+{"level":"info","ts":1651568779.81949,"msg":"Creating TLS certificate provider","issuer":"glbc-ca"}
+{"level":"info","ts":1651568780.865054,"logger":"kcp-glbc-dns","msg":"Creating DNS provider","provider":"aws"}
+{"level":"info","ts":1651568781.389698,"logger":"kcp-glbc-dns","msg":"Using AWS DNS zone","id":"REDACTED"}
+{"level":"info","ts":1651568781.690482,"logger":"kcp-glbc-dns","msg":"Starting workers"}
+{"level":"info","ts":1651568781.690517,"logger":"kcp-glbc-service","msg":"Starting workers"}
+{"level":"info","ts":1651568781.690476,"msg":"Started serving metrics","address":"[::]:8888"}
+{"level":"info","ts":1651568781.690513,"logger":"kcp-glbc-ingress","msg":"Starting workers"}
+{"level":"info","ts":1651568781.6904829,"logger":"kcp-glbc-secrets","msg":"Starting workers"}
+{"level":"info","ts":1651568781.690517,"logger":"kcp-glbc-deployment","msg":"Starting workers"}
+{"level":"info","ts":1651568781.690582,"logger":"kcp-glbc-dns","msg":"Reconciling DNSRecord","dnsRecord":{"apiVersion":"kuadrant.dev/v1","kind":"DNSRecord","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
+{"level":"info","ts":1651568781.690636,"logger":"kcp-glbc-dns","msg":"Skipping zone to which the DNS record is already published","record":{"apiVersion":"kuadrant.dev/v1","kind":"DNSRecord","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"},"zone":{"id":"REDACTED"}}
+{"level":"info","ts":1651568781.693682,"logger":"kcp-glbc-ingress.tracker","msg":"Tracking Service for Ingress","service":{"workspace":"root:default:kcp-glbc","namespace":"default","name":"httpecho-both"},"ingress":{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
+{"level":"info","ts":1651568781.697678,"logger":"kcp-glbc-secrets","msg":"Mirroring TLS secret","name":"rootdefaultkcp-glbc-default-ingress-nondomain","workspace":"root:default:kcp-glbc","namespace":"default"}
+{"level":"info","ts":1651568781.737877,"logger":"kcp-glbc-ingress","msg":"Patching Ingress with TLS Secret","ingress":{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
+{"level":"info","ts":1651568781.875547,"logger":"kcp-glbc-dns","msg":"Reconciling DNSRecord","dnsRecord":{"workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
+{"level":"info","ts":1651568781.875585,"logger":"kcp-glbc-dns","msg":"Skipping zone to which the DNS record is already published","record":{"workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"},"zone":{"id":"REDACTED"}}
+----
+
+Or with the `console` output:
+
+[source,console]
+----
+$ kcp-glbc --zap-encoder=console
+2022-05-03T11:03:19.629+0200    INFO    Creating TLS certificate provider       {"issuer": "glbc-ca"}
+2022-05-03T11:03:23.034+0200    INFO    kcp-glbc-dns    Creating DNS provider   {"provider": "aws"}
+2022-05-03T11:03:23.572+0200    INFO    kcp-glbc-dns    Using AWS DNS zone      {"id": "REDACTED"}
+2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-ingress        Starting workers
+2022-05-03T11:03:23.873+0200    INFO    Started serving metrics {"address": "[::]:8888"}
+2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-service        Starting workers
+2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-deployment     Starting workers
+2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-secrets        Starting workers
+2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-dns    Starting workers
+2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-dns    Reconciling DNSRecord   {"dnsRecord": {"apiVersion": "kuadrant.dev/v1", "kind": "DNSRecord", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
+2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-dns    Skipping zone to which the DNS record is already published      {"record": {"apiVersion": "kuadrant.dev/v1", "kind": "DNSRecord", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}, "zone": {"id":"REDACTED"}}
+2022-05-03T11:03:27.640+0200    INFO    kcp-glbc-ingress.tracker        Tracking Service for Ingress    {"service": {"workspace": "root:default:kcp-glbc", "namespace": "default", "name": "httpecho-both"}, "ingress": {"apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
+2022-05-03T11:03:32.156+0200    INFO    kcp-glbc-secrets        Mirroring TLS secret    {"name": "rootdefaultkcp-glbc-default-ingress-nondomain", "workspace": "root:default:kcp-glbc", "namespace": "default"}
+2022-05-03T11:03:32.198+0200    INFO    kcp-glbc-ingress        Patching Ingress with TLS Secret        {"ingress": {"apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
+2022-05-03T11:03:32.353+0200    INFO    kcp-glbc-dns    Reconciling DNSRecord   {"dnsRecord": {"workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
+2022-05-03T11:03:32.353+0200    INFO    kcp-glbc-dns    Skipping zone to which the DNS record is already published      {"record": {"workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}, "zone": {"id":"REDACTED"}}
+----

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.40.21
+	github.com/go-logr/logr v1.2.0
+	github.com/go-logr/zapr v1.2.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/jetstack/cert-manager v1.7.1
@@ -13,6 +15,7 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rs/xid v1.3.0
+	go.uber.org/zap v1.19.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,7 @@ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNVPunU=
+github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=

--- a/pkg/cluster/mapper.go
+++ b/pkg/cluster/mapper.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kuadrant/kcp-glbc/pkg/tls"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kuadrant/kcp-glbc/pkg/tls"
 )
 
 const (

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -23,5 +23,5 @@ type FakeProvider struct{}
 func (_ *FakeProvider) Ensure(record *v1.DNSRecord, zone v1.DNSZone) error { return nil }
 func (_ *FakeProvider) Delete(record *v1.DNSRecord, zone v1.DNSZone) error { return nil }
 func (*FakeProvider) HealthCheckReconciler() HealthCheckReconciler {
-	return &FakeHealthCheckReconciler{}
+	return &fakeHealthCheckReconciler{}
 }

--- a/pkg/dns/health.go
+++ b/pkg/dns/health.go
@@ -27,14 +27,14 @@ type HealthCheckProtocol string
 const HealthCheckProtocolHTTP HealthCheckProtocol = "HTTP"
 const HealthCheckProtocolHTTPS HealthCheckProtocol = "HTTPS"
 
-type FakeHealthCheckReconciler struct{}
+type fakeHealthCheckReconciler struct{}
 
-func (*FakeHealthCheckReconciler) Reconcile(ctx context.Context, _ HealthCheckSpec, _ *v1.Endpoint) error {
+func (*fakeHealthCheckReconciler) Reconcile(ctx context.Context, _ HealthCheckSpec, _ *v1.Endpoint) error {
 	return nil
 }
 
-func (*FakeHealthCheckReconciler) Delete(ctx context.Context, _ *v1.Endpoint) error {
+func (*fakeHealthCheckReconciler) Delete(ctx context.Context, _ *v1.Endpoint) error {
 	return nil
 }
 
-var _ HealthCheckReconciler = &FakeHealthCheckReconciler{}
+var _ HealthCheckReconciler = &fakeHealthCheckReconciler{}

--- a/pkg/log/flags.go
+++ b/pkg/log/flags.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var levelStrings = map[string]zapcore.Level{
+	"debug": zap.DebugLevel,
+	"info":  zap.InfoLevel,
+	"error": zap.ErrorLevel,
+}
+
+var stackLevelStrings = map[string]zapcore.Level{
+	"info":  zap.InfoLevel,
+	"error": zap.ErrorLevel,
+	"panic": zap.PanicLevel,
+}
+
+type encoderFlag struct {
+	setFunc func(NewEncoderFunc)
+	value   string
+}
+
+var _ flag.Value = &encoderFlag{}
+
+func (ev *encoderFlag) String() string {
+	return ev.value
+}
+
+func (ev *encoderFlag) Type() string {
+	return "encoder"
+}
+
+func (ev *encoderFlag) Set(flagValue string) error {
+	val := strings.ToLower(flagValue)
+	switch val {
+	case "json":
+		ev.setFunc(newJSONEncoder)
+	case "console":
+		ev.setFunc(newConsoleEncoder)
+	default:
+		return fmt.Errorf("invalid encoder value \"%s\"", flagValue)
+	}
+	ev.value = flagValue
+	return nil
+}
+
+type levelFlag struct {
+	setFunc func(zapcore.LevelEnabler)
+	value   string
+}
+
+var _ flag.Value = &levelFlag{}
+
+func (ev *levelFlag) Set(flagValue string) error {
+	level, validLevel := levelStrings[strings.ToLower(flagValue)]
+	if !validLevel {
+		logLevel, err := strconv.Atoi(flagValue)
+		if err != nil {
+			return fmt.Errorf("invalid log level \"%s\"", flagValue)
+		}
+		if logLevel > 0 {
+			intLevel := -1 * logLevel
+			ev.setFunc(zap.NewAtomicLevelAt(zapcore.Level(int8(intLevel))))
+		} else {
+			return fmt.Errorf("invalid log level \"%s\"", flagValue)
+		}
+	} else {
+		ev.setFunc(zap.NewAtomicLevelAt(level))
+	}
+	ev.value = flagValue
+	return nil
+}
+
+func (ev *levelFlag) String() string {
+	return ev.value
+}
+
+func (ev *levelFlag) Type() string {
+	return "level"
+}
+
+type stackTraceFlag struct {
+	setFunc func(zapcore.LevelEnabler)
+	value   string
+}
+
+var _ flag.Value = &stackTraceFlag{}
+
+func (ev *stackTraceFlag) Set(flagValue string) error {
+	level, validLevel := stackLevelStrings[strings.ToLower(flagValue)]
+	if !validLevel {
+		return fmt.Errorf("invalid stacktrace level \"%s\"", flagValue)
+	}
+	ev.setFunc(zap.NewAtomicLevelAt(level))
+	ev.value = flagValue
+	return nil
+}
+
+func (ev *stackTraceFlag) String() string {
+	return ev.value
+}
+
+func (ev *stackTraceFlag) Type() string {
+	return "level"
+}

--- a/pkg/log/kcp.go
+++ b/pkg/log/kcp.go
@@ -34,7 +34,7 @@ type KcpAwareEncoder struct {
 	// Encoder is the zapcore.Encoder that this encoder delegates to
 	zapcore.Encoder
 
-	// Verbose controls whether or not the full object is printed.
+	// Verbose controls whether the full object is printed.
 	// If false, only name, namespace, api version, and kind are printed.
 	// Otherwise, the full object is logged.
 	Verbose bool

--- a/pkg/log/kcp.go
+++ b/pkg/log/kcp.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// KcpAwareEncoder is a KCP-aware Zap Encoder.
+// Instead of trying to force Kubernetes objects to implement
+// ObjectMarshaller, we just implement a wrapper around a normal
+// ObjectMarshaller that checks for Kubernetes objects.
+type KcpAwareEncoder struct {
+	// Encoder is the zapcore.Encoder that this encoder delegates to
+	zapcore.Encoder
+
+	// Verbose controls whether or not the full object is printed.
+	// If false, only name, namespace, api version, and kind are printed.
+	// Otherwise, the full object is logged.
+	Verbose bool
+}
+
+// kcpObjectWrapper is a zapcore.ObjectMarshaler for Kubernetes objects.
+type kcpObjectWrapper struct {
+	obj runtime.Object
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler.
+func (w kcpObjectWrapper) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	// TODO(directxman12): log kind and apiversion if not set explicitly (common case)
+	// -- needs an a scheme to convert to the GVK.
+	if gvk := w.obj.GetObjectKind().GroupVersionKind(); gvk.Version != "" {
+		enc.AddString("apiVersion", gvk.GroupVersion().String())
+		enc.AddString("kind", gvk.Kind)
+	}
+
+	objMeta, err := meta.Accessor(w.obj)
+	if err != nil {
+		return fmt.Errorf("got runtime.Object without object metadata: %v", w.obj)
+	}
+
+	if ns := objMeta.GetClusterName(); ns != "" {
+		enc.AddString("workspace", ns)
+	}
+	if ns := objMeta.GetNamespace(); ns != "" {
+		enc.AddString("namespace", ns)
+	}
+	enc.AddString("name", objMeta.GetName())
+
+	return nil
+}
+
+// Clone implements zapcore.Encoder.
+func (k *KcpAwareEncoder) Clone() zapcore.Encoder {
+	return &KcpAwareEncoder{
+		Encoder: k.Encoder.Clone(),
+	}
+}
+
+// EncodeEntry implements zapcore.Encoder.
+func (k *KcpAwareEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	if k.Verbose {
+		// Kubernetes objects implement fmt.Stringer, so if we
+		// want verbose output, just delegate to that.
+		return k.Encoder.EncodeEntry(entry, fields)
+	}
+
+	for i, field := range fields {
+		// intercept stringer fields that happen to be Kubernetes runtime.Object
+		// *unstructured.Unstructured does NOT implement fmt.Striger interface.
+		// We have handle it specially.
+		if field.Type == zapcore.StringerType || field.Type == zapcore.ReflectType {
+			switch val := field.Interface.(type) {
+			case runtime.Object:
+				fields[i] = zapcore.Field{
+					Type:      zapcore.ObjectMarshalerType,
+					Key:       field.Key,
+					Interface: kcpObjectWrapper{obj: val},
+				}
+			}
+		}
+	}
+
+	return k.Encoder.EncodeEntry(entry, fields)
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,25 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"github.com/go-logr/logr"
+)
+
+var Logger logr.Logger
+
+func init() {
+	Logger = New()
+}

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"flag"
+	"io"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// EncoderConfigOption is a function that can modify a `zapcore.EncoderConfig`.
+type EncoderConfigOption func(*zapcore.EncoderConfig)
+
+// NewEncoderFunc is a function that creates an Encoder using the provided EncoderConfigOptions.
+type NewEncoderFunc func(...EncoderConfigOption) zapcore.Encoder
+
+// New returns a brand new Logger configured with Opts. It
+// uses KcpAwareEncoder which adds Type information and
+// Namespace/Name to the log.
+func New(opts ...Opts) logr.Logger {
+	return zapr.NewLogger(NewRaw(opts...))
+}
+
+// Opts allows to manipulate Options.
+type Opts func(*Options)
+
+// UseDevMode sets the logger to use (or not use) development mode (more
+// human-readable output, extra stack traces and logging information, etc).
+// See Options.Development.
+func UseDevMode(enabled bool) Opts {
+	return func(o *Options) {
+		o.Development = enabled
+	}
+}
+
+// WriteTo configures the logger to write to the given io.Writer, instead of standard error.
+// See Options.DestWriter.
+func WriteTo(out io.Writer) Opts {
+	return func(o *Options) {
+		o.DestWriter = out
+	}
+}
+
+// Encoder configures how the logger will encode the output e.g JSON or console.
+// See Options.Encoder.
+func Encoder(encoder zapcore.Encoder) func(o *Options) {
+	return func(o *Options) {
+		o.Encoder = encoder
+	}
+}
+
+func newJSONEncoder(opts ...EncoderConfigOption) zapcore.Encoder {
+	encoderConfig := zap.NewProductionEncoderConfig()
+	for _, opt := range opts {
+		opt(&encoderConfig)
+	}
+	return zapcore.NewJSONEncoder(encoderConfig)
+}
+
+func newConsoleEncoder(opts ...EncoderConfigOption) zapcore.Encoder {
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	for _, opt := range opts {
+		opt(&encoderConfig)
+	}
+	return zapcore.NewConsoleEncoder(encoderConfig)
+}
+
+// Level sets Options.Level, which configures the minimum enabled logging level e.g. Debug, Info.
+// A zap log level should be multiplied by -1 to get the logr verbosity.
+// For example, to get logr verbosity of 3, pass zapcore.Level(-3) to this Opts.
+// See https://pkg.go.dev/github.com/go-logr/zapr for how zap level relates to logr verbosity.
+func Level(level zapcore.LevelEnabler) func(o *Options) {
+	return func(o *Options) {
+		o.Level = level
+	}
+}
+
+// Options contains all possible settings.
+type Options struct {
+	// Development configures the logger to use a Zap development config
+	// (stacktraces on warnings, no sampling), otherwise a Zap production
+	// config will be used (stacktraces on errors, sampling).
+	Development bool
+	// Encoder configures how Zap will encode the output.  Defaults to
+	// console when Development is true and JSON otherwise
+	Encoder zapcore.Encoder
+	// EncoderConfigOptions can modify the EncoderConfig needed to initialize an Encoder.
+	// See https://godoc.org/go.uber.org/zap/zapcore#EncoderConfig for the list of options
+	// that can be configured.
+	// Note that the EncoderConfigOptions are not applied when the Encoder option is already set.
+	EncoderConfigOptions []EncoderConfigOption
+	// NewEncoder configures Encoder using the provided EncoderConfigOptions.
+	// Note that the NewEncoder function is not used when the Encoder option is already set.
+	NewEncoder NewEncoderFunc
+	// DestWriter controls the destination of the log output.  Defaults to
+	// os.Stderr.
+	DestWriter io.Writer
+	// Level configures the verbosity of the logging.
+	// Defaults to Debug when Development is true and Info otherwise.
+	// A zap log level should be multiplied by -1 to get the logr verbosity.
+	// For example, to get logr verbosity of 3, set this field to zapcore.Level(-3).
+	// See https://pkg.go.dev/github.com/go-logr/zapr for how zap level relates to logr verbosity.
+	Level zapcore.LevelEnabler
+	// StacktraceLevel is the level at and above which stacktraces will
+	// be recorded for all messages. Defaults to Warn when Development
+	// is true and Error otherwise.
+	// See Level for the relationship of zap log level to logr verbosity.
+	StacktraceLevel zapcore.LevelEnabler
+	// ZapOpts allows passing arbitrary zap.Options to configure on the
+	// underlying Zap logger.
+	ZapOpts []zap.Option
+}
+
+// addDefaults adds defaults to the Options.
+func (o *Options) addDefaults() {
+	if o.DestWriter == nil {
+		o.DestWriter = os.Stderr
+	}
+
+	if o.Development {
+		if o.NewEncoder == nil {
+			o.NewEncoder = newConsoleEncoder
+		}
+		if o.Level == nil {
+			lvl := zap.NewAtomicLevelAt(zap.DebugLevel)
+			o.Level = &lvl
+		}
+		if o.StacktraceLevel == nil {
+			lvl := zap.NewAtomicLevelAt(zap.WarnLevel)
+			o.StacktraceLevel = &lvl
+		}
+		o.ZapOpts = append(o.ZapOpts, zap.Development())
+	} else {
+		if o.NewEncoder == nil {
+			o.NewEncoder = newJSONEncoder
+		}
+		if o.Level == nil {
+			lvl := zap.NewAtomicLevelAt(zap.InfoLevel)
+			o.Level = &lvl
+		}
+		if o.StacktraceLevel == nil {
+			lvl := zap.NewAtomicLevelAt(zap.ErrorLevel)
+			o.StacktraceLevel = &lvl
+		}
+		// Disable sampling for increased Debug levels. Otherwise, this will
+		// cause index out of bounds errors in the sampling code.
+		if !o.Level.Enabled(zapcore.Level(-2)) {
+			o.ZapOpts = append(o.ZapOpts,
+				zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+					return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
+				}))
+		}
+	}
+	if o.Encoder == nil {
+		o.Encoder = o.NewEncoder(o.EncoderConfigOptions...)
+	}
+	o.ZapOpts = append(o.ZapOpts, zap.AddStacktrace(o.StacktraceLevel))
+}
+
+// NewRaw returns a new zap.Logger configured with the passed Opts
+// or their defaults. It uses KcpAwareEncoder which adds Type
+// information and Namespace/Name to the log.
+func NewRaw(opts ...Opts) *zap.Logger {
+	o := &Options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	o.addDefaults()
+
+	// this basically mimics New<type>Config, but with a custom sink
+	sink := zapcore.AddSync(o.DestWriter)
+
+	o.ZapOpts = append(o.ZapOpts, zap.AddCallerSkip(1), zap.ErrorOutput(sink))
+	log := zap.New(zapcore.NewCore(&KcpAwareEncoder{Encoder: o.Encoder, Verbose: o.Development}, sink, o.Level))
+	log = log.WithOptions(o.ZapOpts...)
+	return log
+}
+
+// BindFlags will parse the given flagset for zap option flags and set the log options accordingly
+//  zap-devel: Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn)
+//			  Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
+//  zap-encoder: Zap log encoding (one of 'json' or 'console')
+//  zap-log-level:  Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error',
+//			       or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
+//  zap-stacktrace-level: Zap Level at and above which stacktraces are captured (one of 'info', 'error' or 'panic')
+func (o *Options) BindFlags(fs *flag.FlagSet) {
+	// Set Development mode value
+	fs.BoolVar(&o.Development, "zap-devel", o.Development,
+		"Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). "+
+			"Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)")
+
+	// Set Encoder value
+	var encVal encoderFlag
+	encVal.setFunc = func(fromFlag NewEncoderFunc) {
+		o.NewEncoder = fromFlag
+	}
+	fs.Var(&encVal, "zap-encoder", "Zap log encoding (one of 'json' or 'console')")
+
+	// Set the Log Level
+	var levelVal levelFlag
+	levelVal.setFunc = func(fromFlag zapcore.LevelEnabler) {
+		o.Level = fromFlag
+	}
+	fs.Var(&levelVal, "zap-log-level",
+		"Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', "+
+			"or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
+
+	// Set the StrackTrace Level
+	var stackVal stackTraceFlag
+	stackVal.setFunc = func(fromFlag zapcore.LevelEnabler) {
+		o.StacktraceLevel = fromFlag
+	}
+	fs.Var(&stackVal, "zap-stacktrace-level",
+		"Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').")
+}
+
+// UseFlagOptions configures the logger to use the Options set by parsing zap option flags from the CLI.
+//  opts := zap.Options{}
+//  opts.BindFlags(flag.CommandLine)
+//  flag.Parse()
+//  log := zap.New(zap.UseFlagOptions(&opts))
+func UseFlagOptions(in *Options) Opts {
+	return func(o *Options) {
+		*o = *in
+	}
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"k8s.io/klog/v2"
+	"github.com/kuadrant/kcp-glbc/pkg/log"
 )
 
 const defaultMetricsEndpoint = "/metrics"
@@ -34,10 +34,10 @@ type Server struct {
 	listener   net.Listener
 }
 
-func NewServer(port *int) (*Server, error) {
+func NewServer(port int) (*Server, error) {
 	addr := "0"
-	if port != nil && *port != 0 {
-		addr = ":" + strconv.Itoa(*port)
+	if port != 0 {
+		addr = ":" + strconv.Itoa(port)
 	}
 
 	listener, err := newListener(addr)
@@ -61,7 +61,7 @@ func NewServer(port *int) (*Server, error) {
 
 func (s *Server) Start() (err error) {
 	if s.listener == nil {
-		klog.InfoS("Serving metrics is disabled")
+		log.Logger.Info("Serving metrics is disabled")
 		return
 	}
 	defer func() {
@@ -69,7 +69,7 @@ func (s *Server) Start() (err error) {
 			err = fmt.Errorf("serving metrics failed: %v", r)
 		}
 	}()
-	klog.InfoS("Started serving metrics", "address", s.listener.Addr())
+	log.Logger.Info("Started serving metrics", "address", s.listener.Addr())
 	if e := s.httpServer.Serve(s.listener); e != http.ErrServerClosed {
 		err = e
 	}
@@ -80,7 +80,7 @@ func (s *Server) Shutdown() error {
 	if s.listener == nil {
 		return nil
 	}
-	klog.Info("Stopping metrics server")
+	log.Logger.Info("Stopping metrics server")
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	return s.httpServer.Shutdown(shutdownCtx)

--- a/pkg/net/hostresolv.go
+++ b/pkg/net/hostresolv.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -3,10 +3,11 @@ package placement
 import (
 	"fmt"
 
-	kcp "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	kcp "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 )
 
 type Placer interface {


### PR DESCRIPTION
This PR introduces structured logging, by using Zap as logging backend.

It binds Zap configuration to the CLI options, so that it's possible to set logging output either to `console` or `json`, e.g.:

```console
$ kcp-glbc --zap-encoder=json
{"level":"info","ts":1651568779.81949,"msg":"Creating TLS certificate provider","issuer":"glbc-ca"}
{"level":"info","ts":1651568780.865054,"logger":"kcp-glbc-dns","msg":"Creating DNS provider","provider":"aws"}
{"level":"info","ts":1651568781.389698,"logger":"kcp-glbc-dns","msg":"Using AWS DNS zone","id":"REDACTED"}
{"level":"info","ts":1651568781.690482,"logger":"kcp-glbc-dns","msg":"Starting workers"}
{"level":"info","ts":1651568781.690517,"logger":"kcp-glbc-service","msg":"Starting workers"}
{"level":"info","ts":1651568781.690476,"msg":"Started serving metrics","address":"[::]:8888"}
{"level":"info","ts":1651568781.690513,"logger":"kcp-glbc-ingress","msg":"Starting workers"}
{"level":"info","ts":1651568781.6904829,"logger":"kcp-glbc-secrets","msg":"Starting workers"}
{"level":"info","ts":1651568781.690517,"logger":"kcp-glbc-deployment","msg":"Starting workers"}
{"level":"info","ts":1651568781.690582,"logger":"kcp-glbc-dns","msg":"Reconciling DNSRecord","dnsRecord":{"apiVersion":"kuadrant.dev/v1","kind":"DNSRecord","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
{"level":"info","ts":1651568781.690636,"logger":"kcp-glbc-dns","msg":"Skipping zone to which the DNS record is already published","record":{"apiVersion":"kuadrant.dev/v1","kind":"DNSRecord","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"},"zone":{"id":"REDACTED"}}
{"level":"info","ts":1651568781.693682,"logger":"kcp-glbc-ingress.tracker","msg":"Tracking Service for Ingress","service":{"workspace":"root:default:kcp-glbc","namespace":"default","name":"httpecho-both"},"ingress":{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
{"level":"info","ts":1651568781.697678,"logger":"kcp-glbc-secrets","msg":"Mirroring TLS secret","name":"rootdefaultkcp-glbc-default-ingress-nondomain","workspace":"root:default:kcp-glbc","namespace":"default"}
{"level":"info","ts":1651568781.737877,"logger":"kcp-glbc-ingress","msg":"Patching Ingress with TLS Secret","ingress":{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
{"level":"info","ts":1651568781.875547,"logger":"kcp-glbc-dns","msg":"Reconciling DNSRecord","dnsRecord":{"workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"}}
{"level":"info","ts":1651568781.875585,"logger":"kcp-glbc-dns","msg":"Skipping zone to which the DNS record is already published","record":{"workspace":"root:default:kcp-glbc","namespace":"default","name":"ingress-nondomain"},"zone":{"id":"REDACTED"}}
```

```console
$ kcp-glbc --zap-encoder=console
2022-05-03T11:03:19.629+0200    INFO    Creating TLS certificate provider       {"issuer": "glbc-ca"}
2022-05-03T11:03:23.034+0200    INFO    kcp-glbc-dns    Creating DNS provider   {"provider": "aws"}
2022-05-03T11:03:23.572+0200    INFO    kcp-glbc-dns    Using AWS DNS zone      {"id": "REDACTED"}
2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-ingress        Starting workers
2022-05-03T11:03:23.873+0200    INFO    Started serving metrics {"address": "[::]:8888"}
2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-service        Starting workers
2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-deployment     Starting workers
2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-secrets        Starting workers
2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-dns    Starting workers
2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-dns    Reconciling DNSRecord   {"dnsRecord": {"apiVersion": "kuadrant.dev/v1", "kind": "DNSRecord", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
2022-05-03T11:03:23.873+0200    INFO    kcp-glbc-dns    Skipping zone to which the DNS record is already published      {"record": {"apiVersion": "kuadrant.dev/v1", "kind": "DNSRecord", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}, "zone": {"id":"REDACTED"}}
2022-05-03T11:03:27.640+0200    INFO    kcp-glbc-ingress.tracker        Tracking Service for Ingress    {"service": {"workspace": "root:default:kcp-glbc", "namespace": "default", "name": "httpecho-both"}, "ingress": {"apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
2022-05-03T11:03:32.156+0200    INFO    kcp-glbc-secrets        Mirroring TLS secret    {"name": "rootdefaultkcp-glbc-default-ingress-nondomain", "workspace": "root:default:kcp-glbc", "namespace": "default"}
2022-05-03T11:03:32.198+0200    INFO    kcp-glbc-ingress        Patching Ingress with TLS Secret        {"ingress": {"apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
2022-05-03T11:03:32.353+0200    INFO    kcp-glbc-dns    Reconciling DNSRecord   {"dnsRecord": {"workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}}
2022-05-03T11:03:32.353+0200    INFO    kcp-glbc-dns    Skipping zone to which the DNS record is already published      {"record": {"workspace": "root:default:kcp-glbc", "namespace": "default", "name": "ingress-nondomain"}, "zone": {"id":"REDACTED"}}
``` 