### PR TITLE
Apply KCP syncer resources using dynamic client

### DIFF
--- a/e2e/common.go
+++ b/e2e/common.go
@@ -20,15 +20,12 @@ package e2e
 import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	appsv1apply "k8s.io/client-go/applyconfigurations/apps/v1"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	v1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	networkingv1apply "k8s.io/client-go/applyconfigurations/networking/v1"
 )
-
-var applyOptions = metav1.ApplyOptions{FieldManager: "kcp-glbc-e2e", Force: true}
 
 func ingressConfiguration(namespace, name string) *networkingv1apply.IngressApplyConfiguration {
 	return networkingv1apply.Ingress(name, namespace).WithSpec(

--- a/e2e/ingress_test.go
+++ b/e2e/ingress_test.go
@@ -44,7 +44,7 @@ func TestIngress(t *testing.T) {
 		Should(BeTrue())
 
 	// Register workload cluster 1 into the test workspace
-	cluster1 := test.NewWorkloadCluster(workspace, "kcp-cluster-1")
+	cluster1 := test.NewWorkloadCluster("kcp-cluster-1", InWorkspace(workspace), WithKubeConfigByName, Syncer().ResourcesToSync(GLBCResources...))
 
 	// Wait until cluster 1 is ready
 	test.Eventually(WorkloadCluster(test, cluster1.ClusterName, cluster1.Name)).WithTimeout(time.Minute * 3).Should(WithTransform(
@@ -66,17 +66,17 @@ func TestIngress(t *testing.T) {
 
 	// Create the root Deployment
 	_, err := test.Client().Core().Cluster(logicalcluster.From(namespace)).AppsV1().Deployments(namespace.Name).
-		Apply(test.Ctx(), deploymentConfiguration(namespace.Name, name), applyOptions)
+		Apply(test.Ctx(), deploymentConfiguration(namespace.Name, name), ApplyOptions)
 	test.Expect(err).NotTo(HaveOccurred())
 
 	// Create the root Service
 	_, err = test.Client().Core().Cluster(logicalcluster.From(namespace)).CoreV1().Services(namespace.Name).
-		Apply(test.Ctx(), serviceConfiguration(namespace.Name, name, map[string]string{}), applyOptions)
+		Apply(test.Ctx(), serviceConfiguration(namespace.Name, name, map[string]string{}), ApplyOptions)
 	test.Expect(err).NotTo(HaveOccurred())
 
 	// Create the root Ingress
 	_, err = test.Client().Core().Cluster(logicalcluster.From(namespace)).NetworkingV1().Ingresses(namespace.Name).
-		Apply(test.Ctx(), ingressConfiguration(namespace.Name, name), applyOptions)
+		Apply(test.Ctx(), ingressConfiguration(namespace.Name, name), ApplyOptions)
 	test.Expect(err).NotTo(HaveOccurred())
 
 	// Wait until the root Ingress is reconciled with the load balancer Ingresses
@@ -108,7 +108,7 @@ func TestIngress(t *testing.T) {
 	))
 
 	// Register workload cluster 2 into the test workspace
-	cluster2 := test.NewWorkloadCluster(workspace, "kcp-cluster-2")
+	cluster2 := test.NewWorkloadCluster("kcp-cluster-2", InWorkspace(workspace), WithKubeConfigByName, Syncer().ResourcesToSync(GLBCResources...))
 
 	// Wait until cluster 2 is ready
 	test.Eventually(WorkloadCluster(test, cluster2.ClusterName, cluster2.Name)).WithTimeout(time.Minute * 3).Should(WithTransform(
@@ -117,7 +117,7 @@ func TestIngress(t *testing.T) {
 	))
 
 	// update the namespace with the second cluster placement
-	_, err = test.Client().Core().Cluster(logicalcluster.From(namespace)).CoreV1().Namespaces().Apply(test.Ctx(), corev1apply.Namespace(namespace.Name).WithLabels(map[string]string{kcp.ClusterLabel: cluster2.Name}), applyOptions)
+	_, err = test.Client().Core().Cluster(logicalcluster.From(namespace)).CoreV1().Namespaces().Apply(test.Ctx(), corev1apply.Namespace(namespace.Name).WithLabels(map[string]string{kcp.ClusterLabel: cluster2.Name}), ApplyOptions)
 
 	test.Expect(err).NotTo(HaveOccurred())
 	// Wait until the root Ingress is reconciled with the load balancer Ingresses

--- a/e2e/support/cluster.go
+++ b/e2e/support/cluster.go
@@ -5,103 +5,224 @@ package support
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
-	"os/exec"
 	"path"
 
-	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	"github.com/onsi/gomega"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	workloadplugin "github.com/kcp-dev/kcp/pkg/cliplugins/workload/plugin"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func createWorkloadCluster(t Test, workspace *tenancyv1alpha1.ClusterWorkspace, name string) *workloadv1alpha1.WorkloadCluster {
+var (
+	GLBCResources = []string{"ingresses.networking.k8s.io", "services", "deployments.apps", "secrets", "configmaps"}
 
-	logicalClusterName := logicalcluster.From(workspace).Join(workspace.Name).String()
+	WithKubeConfigByName = &withKubeConfigByName{}
 
-	//Run workload plugin sync command
-	syncerResources, err := execKcpWorkloadSync(t, name, logicalClusterName)
-	t.Expect(err).NotTo(gomega.HaveOccurred())
+	_ Option = &withKubeConfigByName{}
+	_ Option = &withKubeConfigByID{}
+	_ Option = &syncer{}
+)
 
-	//Apply syncer resources to workload cluster
-	err = workloadClusterKubeCtlApply(name, syncerResources)
+type withKubeConfigByName struct{}
+
+func WithKubeConfigByID(id string) Option {
+	return &withKubeConfigByID{id}
+}
+
+type withKubeConfigByID struct {
+	ID string
+}
+
+func (o *withKubeConfigByName) applyTo(to interface{}) error {
+	config, ok := to.(*workloadClusterConfig)
+	if !ok {
+		return fmt.Errorf("cannot apply WithKubeConfigByName to %q", to)
+	}
+	return WithKubeConfigByID(config.name).applyTo(config)
+}
+
+func (o *withKubeConfigByID) applyTo(to interface{}) error {
+	config, ok := to.(*workloadClusterConfig)
+	if !ok {
+		return fmt.Errorf("cannot apply WithKubeConfigById to %q", to)
+	}
+	dir := os.Getenv(workloadClusterKubeConfigDir)
+	if dir == "" {
+		return fmt.Errorf("%s environment variable is not set", workloadClusterKubeConfigDir)
+	}
+
+	config.kubeConfigPath = path.Join(dir, o.ID+".kubeconfig")
+
+	return nil
+}
+
+func Syncer() *syncer {
+	return &syncer{
+		// TODO: allow this to be set based on the KCP version exported by default
+		image:     "ghcr.io/kcp-dev/kcp/syncer:release-0.4",
+		namespace: "default",
+		replicas:  1,
+	}
+}
+
+type syncer struct {
+	image           string
+	namespace       string
+	replicas        int
+	resourcesToSync []string
+}
+
+func (s *syncer) Image(image string) *syncer {
+	s.image = image
+	return s
+}
+
+func (s *syncer) Namespace(namespace string) *syncer {
+	s.namespace = namespace
+	return s
+}
+
+func (s *syncer) Replicas(replicas int) *syncer {
+	s.replicas = replicas
+	return s
+}
+
+func (s *syncer) ResourcesToSync(resourcesToSync ...string) *syncer {
+	s.resourcesToSync = resourcesToSync
+	return s
+}
+
+func (s *syncer) applyTo(to interface{}) error {
+	config, ok := to.(*workloadClusterConfig)
+	if !ok {
+		return fmt.Errorf("cannot apply WithKubeConfigByName to %q", to)
+	}
+	config.syncer = *s
+	return nil
+}
+
+type workloadClusterConfig struct {
+	name           string
+	kubeConfigPath string
+	workspace      *tenancyv1alpha1.ClusterWorkspace
+	syncer         syncer
+}
+
+func createWorkloadCluster(t Test, name string, options ...Option) *workloadv1alpha1.WorkloadCluster {
+	config := &workloadClusterConfig{
+		name: name,
+	}
+
+	for _, option := range options {
+		t.Expect(option.applyTo(config)).To(gomega.Succeed())
+	}
+
+	t.Expect(config.workspace).NotTo(gomega.BeNil())
+	t.Expect(config.kubeConfigPath).NotTo(gomega.BeEmpty())
+
+	// Run the KCP workload plugin sync command
+	err := applyKcpWorkloadSync(t, config)
 	t.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// Get the workload cluster and return it
-	c, err := t.Client().Kcp().Cluster(logicalcluster.New(logicalClusterName)).WorkloadV1alpha1().WorkloadClusters().Get(t.Ctx(), name, metav1.GetOptions{})
+	workloadCluster, err := t.Client().Kcp().Cluster(logicalcluster.From(config.workspace).Join(config.workspace.Name)).WorkloadV1alpha1().WorkloadClusters().Get(t.Ctx(), name, metav1.GetOptions{})
 	t.Expect(err).NotTo(gomega.HaveOccurred())
 
-	return c
+	return workloadCluster
 }
 
-func execKcpWorkloadSync(t Test, workloadClusterName, logicalClusterName string) (string, error) {
+func applyKcpWorkloadSync(t Test, config *workloadClusterConfig) error {
+	// Configure workload plugin kubeconfig for test workspace
+	logicalClusterName := logicalcluster.From(config.workspace).Join(config.workspace.Name).String()
 	clusterServer := fmt.Sprintf("%s/clusters/%s", t.Client().GetConfig().Host, logicalClusterName)
-	//Configure workload plugin kubeconfig for test workspace
-	outBuffer := new(bytes.Buffer)
-	opts := workloadplugin.NewOptions(genericclioptions.IOStreams{In: os.Stdin, Out: outBuffer, ErrOut: os.Stderr})
+	syncCommandOutput := new(bytes.Buffer)
+	opts := workloadplugin.NewOptions(genericclioptions.IOStreams{In: os.Stdin, Out: syncCommandOutput, ErrOut: os.Stderr})
 	opts.KubectlOverrides.ClusterInfo.Server = clusterServer
-	kubeconfig, err := workloadplugin.NewConfig(opts)
-	if err != nil {
-		return "", err
-	}
-
-	//Workload plugin sync options
-	//ToDo allow this to be set based on the KCP version exported
-	syncerImage := "ghcr.io/kcp-dev/kcp/syncer:release-0.4"
-	replicas := 1
-	kcpNamespaceName := "default" //Creates service account here
-	requiredResourcesToSync := sets.NewString("deployments.apps", "secrets", "configmaps", "serviceaccounts")
-	userResourcesToSync := sets.NewString("ingresses.networking.k8s.io", "services")
-	resourcesToSync := userResourcesToSync.Union(requiredResourcesToSync).List()
-
-	//Run workload plugin sync command
-	err = kubeconfig.Sync(t.Ctx(), workloadClusterName, kcpNamespaceName, syncerImage, resourcesToSync, replicas)
-	if err != nil {
-		return "", err
-	}
-
-	//Write temp file with syncer resources
-	tmpFile, err := ioutil.TempFile(t.T().TempDir(), "syncer-")
-	if err != nil {
-		return "", err
-	}
-	_, err = tmpFile.Write(outBuffer.Bytes())
-	if err != nil {
-		return "", err
-	}
-	err = tmpFile.Close()
-
-	return tmpFile.Name(), err
-}
-
-func kubeCtlApply(kubeconfig, file string) error {
-	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "apply", "-f", file)
-	return cmd.Run()
-}
-
-func workloadClusterKubeConfig(name string) (string, error) {
-	dir := os.Getenv(workloadClusterKubeConfigDir)
-	if dir == "" {
-		return "", fmt.Errorf("%s environment variable is not set", workloadClusterKubeConfigDir)
-	}
-	return path.Join(dir, name+".kubeconfig"), nil
-}
-
-func workloadClusterKubeCtlApply(clusterName, file string) error {
-	clusterKubeconfig, err := workloadClusterKubeConfig(clusterName)
+	plugin, err := workloadplugin.NewConfig(opts)
 	if err != nil {
 		return err
 	}
-	return kubeCtlApply(clusterKubeconfig, file)
+
+	// Run workload plugin sync command
+	requiredResourcesToSync := sets.NewString("deployments.apps", "secrets", "configmaps", "serviceaccounts")
+	userResourcesToSync := sets.NewString(config.syncer.resourcesToSync...)
+	resourcesToSync := userResourcesToSync.Union(requiredResourcesToSync).List()
+	err = plugin.Sync(t.Ctx(), config.name, config.syncer.namespace, config.syncer.image, resourcesToSync, config.syncer.replicas)
+	if err != nil {
+		return err
+	}
+
+	// Apply the syncer resources to the workload cluster
+	clientConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.kubeConfigPath},
+		&clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := dynamic.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	discoClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+	cachedDiscoClient := memory.NewMemCacheClient(discoClient)
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoClient)
+
+	decoder := yaml.NewYAMLToJSONDecoder(bytes.NewReader(syncCommandOutput.Bytes()))
+
+	for {
+		resource := &unstructured.Unstructured{}
+		err := decoder.Decode(resource)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		mapping, err := restMapper.RESTMapping(resource.GroupVersionKind().GroupKind(), resource.GroupVersionKind().Version)
+		if err != nil {
+			return err
+		}
+		_, err = client.Resource(mapping.Resource).Namespace(resource.GetNamespace()).Create(t.Ctx(), resource, metav1.CreateOptions{})
+		if err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return err
+			}
+			data, err := json.Marshal(resource)
+			if err != nil {
+				return err
+			}
+			_, err = client.Resource(mapping.Resource).Namespace(resource.GetNamespace()).Patch(t.Ctx(), resource.GetName(), types.ApplyPatchType, data, ApplyOptions.ToPatchOptions())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func WorkloadCluster(t Test, workspace, name string) func(g gomega.Gomega) *workloadv1alpha1.WorkloadCluster {

--- a/e2e/support/core.go
+++ b/e2e/support/core.go
@@ -4,11 +4,18 @@
 package support
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	conditionsutil "github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+var (
+	_ Option = &withLabel{}
+	_ Option = &withLabels{}
 )
 
 func WithLabel(key, value string) Option {
@@ -19,7 +26,11 @@ type withLabel struct {
 	key, value string
 }
 
-func (o *withLabel) applyTo(object metav1.Object) error {
+func (o *withLabel) applyTo(to interface{}) error {
+	object, ok := to.(metav1.Object)
+	if !ok {
+		return fmt.Errorf("cannot apply option %q to %q", o, to)
+	}
 	if object.GetLabels() == nil {
 		object.SetLabels(map[string]string{})
 	}
@@ -35,7 +46,11 @@ type withLabels struct {
 	labels map[string]string
 }
 
-func (o *withLabels) applyTo(object metav1.Object) error {
+func (o *withLabels) applyTo(to interface{}) error {
+	object, ok := to.(metav1.Object)
+	if !ok {
+		return fmt.Errorf("cannot apply option %q to %q", o, to)
+	}
 	object.SetLabels(o.labels)
 	return nil
 }

--- a/e2e/support/support.go
+++ b/e2e/support/support.go
@@ -9,6 +9,8 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 )
 
@@ -20,7 +22,10 @@ const (
 	workloadClusterKubeConfigDir = "CLUSTERS_KUBECONFIG_DIR"
 )
 
-var TestOrganization = tenancyv1alpha1.RootCluster.Join("default")
+var (
+	TestOrganization = tenancyv1alpha1.RootCluster.Join("default")
+	ApplyOptions     = metav1.ApplyOptions{FieldManager: "kcp-glbc-e2e", Force: true}
+)
 
 func init() {
 	// Gomega settings

--- a/e2e/support/test.go
+++ b/e2e/support/test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
@@ -28,11 +27,11 @@ type Test interface {
 	NewTestWorkspace() *tenancyv1alpha1.ClusterWorkspace
 	NewGLBCAPIBinding(...Option) *apisv1alpha1.APIBinding
 	NewTestNamespace(...Option) *corev1.Namespace
-	NewWorkloadCluster(workspace *tenancyv1alpha1.ClusterWorkspace, name string) *workloadv1alpha1.WorkloadCluster
+	NewWorkloadCluster(name string, options ...Option) *workloadv1alpha1.WorkloadCluster
 }
 
 type Option interface {
-	applyTo(metav1.Object) error
+	applyTo(interface{}) error
 }
 
 func With(t *testing.T) Test {
@@ -101,6 +100,6 @@ func (t *T) NewTestNamespace(options ...Option) *corev1.Namespace {
 	return namespace
 }
 
-func (t *T) NewWorkloadCluster(workspace *tenancyv1alpha1.ClusterWorkspace, name string) *workloadv1alpha1.WorkloadCluster {
-	return createWorkloadCluster(t, workspace, name)
+func (t *T) NewWorkloadCluster(name string, options ...Option) *workloadv1alpha1.WorkloadCluster {
+	return createWorkloadCluster(t, name, options...)
 }

--- a/e2e/support/workspace.go
+++ b/e2e/support/workspace.go
@@ -4,6 +4,8 @@
 package support
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/onsi/gomega"
 
@@ -23,9 +25,22 @@ type inWorkspace struct {
 	workspace *tenancyv1alpha1.ClusterWorkspace
 }
 
-func (o *inWorkspace) applyTo(object metav1.Object) error {
-	clusterName := logicalcluster.From(o.workspace).Join(o.workspace.Name).String()
-	object.SetClusterName(clusterName)
+var _ Option = &inWorkspace{}
+
+func (o *inWorkspace) applyTo(to interface{}) error {
+	logicalCluster := logicalcluster.From(o.workspace).Join(o.workspace.Name)
+
+	switch obj := to.(type) {
+	case metav1.Object:
+		obj.SetClusterName(logicalCluster.String())
+
+	case *workloadClusterConfig:
+		obj.workspace = o.workspace
+
+	default:
+		return fmt.Errorf("cannot apply InWorkspace option to %q", to)
+	}
+
 	return nil
 }
 

--- a/e2e/tls_test.go
+++ b/e2e/tls_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
+
 	. "github.com/kuadrant/kcp-glbc/e2e/support"
 	kuadrantv1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
 	kuadrantcluster "github.com/kuadrant/kcp-glbc/pkg/cluster"
@@ -57,7 +58,7 @@ func TestTLS(t *testing.T) {
 		Should(BeTrue())
 
 	// Register workload cluster 1 into the test workspace
-	cluster1 := test.NewWorkloadCluster(workspace, "kcp-cluster-1")
+	cluster1 := test.NewWorkloadCluster("kcp-cluster-1", InWorkspace(workspace), WithKubeConfigByName, Syncer().ResourcesToSync(GLBCResources...))
 
 	// Wait until cluster 1 is ready
 	test.Eventually(WorkloadCluster(test, cluster1.ClusterName, cluster1.Name)).WithTimeout(time.Minute * 3).Should(WithTransform(
@@ -79,17 +80,17 @@ func TestTLS(t *testing.T) {
 
 	// Create the root Deployment
 	_, err := test.Client().Core().Cluster(logicalcluster.From(namespace)).AppsV1().Deployments(namespace.Name).
-		Apply(test.Ctx(), deploymentConfiguration(namespace.Name, name), applyOptions)
+		Apply(test.Ctx(), deploymentConfiguration(namespace.Name, name), ApplyOptions)
 	test.Expect(err).NotTo(HaveOccurred())
 
 	// Create the root Service
 	_, err = test.Client().Core().Cluster(logicalcluster.From(namespace)).CoreV1().Services(namespace.Name).
-		Apply(test.Ctx(), serviceConfiguration(namespace.Name, name, map[string]string{}), applyOptions)
+		Apply(test.Ctx(), serviceConfiguration(namespace.Name, name, map[string]string{}), ApplyOptions)
 	test.Expect(err).NotTo(HaveOccurred())
 
 	// Create the root Ingress
 	_, err = test.Client().Core().Cluster(logicalcluster.From(namespace)).NetworkingV1().Ingresses(namespace.Name).
-		Apply(test.Ctx(), ingressConfiguration(namespace.Name, name), applyOptions)
+		Apply(test.Ctx(), ingressConfiguration(namespace.Name, name), ApplyOptions)
 	test.Expect(err).NotTo(HaveOccurred())
 
 	// Wait until the root Ingress is reconciled with the load balancer Ingresses


### PR DESCRIPTION
This follows up #131, to apply the KCP syncer resources using client-go dynamic client, instead of spawning a `kubectl` command, when creating a WorkloadCluster in the e2e tests.