### PR TITLE
Enable grafana basic auth

### DIFF
--- a/config/grafana/auth-proxy/grafana.yaml
+++ b/config/grafana/auth-proxy/grafana.yaml
@@ -12,13 +12,14 @@ spec:
     auth:
       disable_login_form: True
       disable_signout_menu: True
-    auth.basic:
-      enabled: False
     auth.proxy:
       enabled: True
       enable_login_token: True
       header_property: username
       header_name: X-Forwarded-User
+    security:
+      admin_user: "admin"
+      admin_password: "admin"
     users:
       viewers_can_edit: True
       auto_assign_org_role: Admin


### PR DESCRIPTION
The grafana operator requires the default admin user and basic auth to be enabled in order to reconcile dashboard resources.

Fixes https://github.com/Kuadrant/kcp-glbc/issues/142