### PR TITLE
Remove hostname label from TLS certificate metrics

### DIFF
--- a/docs/observability/monitoring.adoc
+++ b/docs/observability/monitoring.adoc
@@ -143,18 +143,18 @@ The metrics can then be retrieved by _GETTing_ the `/metrics` endpoint, e.g.:
 $ curl http://localhost:8888/metrics | grep "glbc_tls"
 # HELP glbc_tls_certificate_issuance_duration_seconds GLBC TLS certificate issuance duration
 # TYPE glbc_tls_certificate_issuance_duration_seconds histogram
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="1"} 0
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="5"} 0
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="10"} 0
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="15"} 0
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="30"} 0
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="45"} 0
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="60"} 0
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="120"} 1
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="300"} 1
-glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="",result="succeeded",le="+Inf"} 1
-glbc_tls_certificate_issuance_duration_seconds_sum{issuer="",result="succeeded"} 93
-glbc_tls_certificate_issuance_duration_seconds_count{issuer="",result="succeeded"} 1
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="1"} 0
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="5"} 0
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="10"} 0
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="15"} 0
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="30"} 0
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="45"} 0
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="60"} 0
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="120"} 1
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="300"} 1
+glbc_tls_certificate_issuance_duration_seconds_bucket{issuer="letsencryptstaging",result="succeeded",le="+Inf"} 1
+glbc_tls_certificate_issuance_duration_seconds_sum{issuer="letsencryptstaging",result="succeeded"} 93
+glbc_tls_certificate_issuance_duration_seconds_count{issuer="letsencryptstaging",result="succeeded"} 1
 # HELP glbc_tls_certificate_pending_request_count GLBC TLS certificate pending request count
 # TYPE glbc_tls_certificate_pending_request_count gauge
 glbc_tls_certificate_pending_request_count{issuer="letsencryptstaging"} 0
@@ -216,7 +216,7 @@ The KCP GLBC monitoring endpoint exposes the metrics listed in the following sec
 | `glbc_tls_certificate_secret_count`
 | `GaugeVec`
 | Current number of TLS certificate Secrets
-| `issuer`, `hostname`
+| `issuer`
 
 | `glbc_tls_certificate_pending_request_count`
 | `GaugeVec`
@@ -226,17 +226,17 @@ The KCP GLBC monitoring endpoint exposes the metrics listed in the following sec
 | `glbc_tls_certificate_request_total`
 | `CounterVec`
 | Total number of TLS certificate requests
-| `issuer`, `hostname`, `result`
+| `issuer`, `result`
 
 | `glbc_tls_certificate_request_errors_total`
 | `CounterVec`
 | Total number of failed TLS certificate requests
-| `issuer`, `hostname`
+| `issuer`
 
 | `glbc_tls_certificate_issuance_duration_seconds`
 | `HistogramVec`
 | Duration of the TLS certificate issuance
-| `issuer`, `hostname`, `result`
+| `issuer`, `result`
 
 |===
 

--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -126,7 +126,7 @@ func TestMetrics(t *testing.T) {
 					Metric: []*prometheus.Metric{
 						{
 							Label: []*prometheus.LabelPair{
-								label("host", hostname),
+								label("hostname", hostname),
 								label("issuer", issuer),
 							},
 							Gauge: &prometheus.Gauge{
@@ -135,7 +135,7 @@ func TestMetrics(t *testing.T) {
 						},
 						{
 							Label: []*prometheus.LabelPair{
-								label("host", domain),
+								label("hostname", domain),
 								label("issuer", issuer),
 							},
 							Gauge: &prometheus.Gauge{
@@ -194,7 +194,7 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("host", hostname),
+							label("hostname", hostname),
 							label("issuer", issuer),
 						},
 						Gauge: &prometheus.Gauge{
@@ -203,7 +203,7 @@ func TestMetrics(t *testing.T) {
 					},
 					{
 						Label: []*prometheus.LabelPair{
-							label("host", domain),
+							label("hostname", domain),
 							label("issuer", issuer),
 						},
 						Gauge: &prometheus.Gauge{
@@ -360,7 +360,7 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("host", hostname),
+							label("hostname", hostname),
 							label("issuer", issuer),
 						},
 						Gauge: &prometheus.Gauge{
@@ -369,7 +369,7 @@ func TestMetrics(t *testing.T) {
 					},
 					{
 						Label: []*prometheus.LabelPair{
-							label("host", domain),
+							label("hostname", domain),
 							label("issuer", issuer),
 						},
 						Gauge: &prometheus.Gauge{

--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -225,17 +225,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", hostname),
-							label("issuer", issuer),
-							label("result", "succeeded"),
-						},
-						Counter: &prometheus.Counter{
-							Value: float64P(1),
-						},
-					},
-					{
-						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 							label("result", "failed"),
 						},
@@ -245,12 +234,11 @@ func TestMetrics(t *testing.T) {
 					},
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 							label("result", "succeeded"),
 						},
 						Counter: &prometheus.Counter{
-							Value: float64P(0),
+							Value: float64P(1),
 						},
 					},
 				},
@@ -268,7 +256,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 						},
 						Counter: &prometheus.Counter{
@@ -289,7 +276,6 @@ func TestMetrics(t *testing.T) {
 				"Type": EqualP(prometheus.MetricType_GAUGE),
 				"Metric": ContainElement(&prometheus.Metric{
 					Label: []*prometheus.LabelPair{
-						label("hostname", hostname),
 						label("issuer", issuer),
 					},
 					Gauge: &prometheus.Gauge{
@@ -313,7 +299,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", hostname),
 							label("issuer", issuer),
 							label("result", "succeeded"),
 						},
@@ -354,7 +339,6 @@ func TestMetrics(t *testing.T) {
 				"Type": EqualP(prometheus.MetricType_GAUGE),
 				"Metric": ContainElement(&prometheus.Metric{
 					Label: []*prometheus.LabelPair{
-						label("hostname", hostname),
 						label("issuer", issuer),
 					},
 					Gauge: &prometheus.Gauge{
@@ -404,17 +388,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", hostname),
-							label("issuer", issuer),
-							label("result", "succeeded"),
-						},
-						Counter: &prometheus.Counter{
-							Value: float64P(1),
-						},
-					},
-					{
-						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 							label("result", "failed"),
 						},
@@ -424,12 +397,11 @@ func TestMetrics(t *testing.T) {
 					},
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 							label("result", "succeeded"),
 						},
 						Counter: &prometheus.Counter{
-							Value: float64P(0),
+							Value: float64P(1),
 						},
 					},
 				},
@@ -444,7 +416,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 						},
 						Counter: &prometheus.Counter{
@@ -463,7 +434,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", hostname),
 							label("issuer", issuer),
 							label("result", "succeeded"),
 						},

--- a/pkg/reconciler/tls/controller.go
+++ b/pkg/reconciler/tls/controller.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/kuadrant/kcp-glbc/pkg/cluster"
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler"
 )
 
@@ -47,9 +46,8 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 		AddFunc: func(obj interface{}) {
 			secret := obj.(*corev1.Secret)
 			issuer, hasIssuer := secret.Annotations[tlsIssuerAnnotation]
-			hostname, hasHostname := secret.Annotations[cluster.ANNOTATION_HCG_HOST]
-			if hasIssuer && hasHostname {
-				tlsCertificateSecretCount.WithLabelValues(issuer, hostname).Inc()
+			if hasIssuer {
+				tlsCertificateSecretCount.WithLabelValues(issuer).Inc()
 			}
 			c.Enqueue(obj)
 		},
@@ -59,9 +57,8 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 		DeleteFunc: func(obj interface{}) {
 			secret := obj.(*corev1.Secret)
 			issuer, hasIssuer := secret.Annotations[tlsIssuerAnnotation]
-			hostname, hasHostname := secret.Annotations[cluster.ANNOTATION_HCG_HOST]
-			if hasIssuer && hasHostname {
-				tlsCertificateSecretCount.WithLabelValues(issuer, hostname).Dec()
+			if hasIssuer {
+				tlsCertificateSecretCount.WithLabelValues(issuer).Dec()
 			}
 			c.Enqueue(obj)
 		},

--- a/pkg/reconciler/tls/metrics.go
+++ b/pkg/reconciler/tls/metrics.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	issuerLabel          = "issuer"
-	hostnameLabel        = "hostname"
 	resultLabel          = "result"
 	resultLabelSucceeded = "succeeded"
 	// FIXME: Refactor TLS certificate management to be able to monitor errors
@@ -43,7 +42,6 @@ var (
 		},
 		[]string{
 			issuerLabel,
-			hostnameLabel,
 			resultLabel,
 		},
 	)
@@ -58,7 +56,6 @@ var (
 		// TODO: check if it's possible to add an error/code label
 		[]string{
 			issuerLabel,
-			hostnameLabel,
 		},
 	)
 
@@ -82,7 +79,6 @@ var (
 		},
 		[]string{
 			issuerLabel,
-			hostnameLabel,
 			resultLabel,
 		},
 	)
@@ -96,7 +92,6 @@ var (
 		},
 		[]string{
 			issuerLabel,
-			hostnameLabel,
 		},
 	)
 )
@@ -114,12 +109,10 @@ func init() {
 func InitMetrics(provider tls.Provider) {
 	// Initialize metrics
 	issuer := provider.IssuerID()
-	for _, domain := range provider.Domains() {
-		tlsCertificateRequestTotal.WithLabelValues(issuer, domain, resultLabelSucceeded).Add(0)
-		tlsCertificateRequestTotal.WithLabelValues(issuer, domain, resultLabelFailed).Add(0)
-		tlsCertificateRequestErrors.WithLabelValues(issuer, domain).Add(0)
-		tlsCertificateSecretCount.WithLabelValues(issuer, domain).Set(0)
-	}
+	tlsCertificateRequestTotal.WithLabelValues(issuer, resultLabelSucceeded).Add(0)
+	tlsCertificateRequestTotal.WithLabelValues(issuer, resultLabelFailed).Add(0)
+	tlsCertificateRequestErrors.WithLabelValues(issuer).Add(0)
+	tlsCertificateSecretCount.WithLabelValues(issuer).Set(0)
 
 	tls.InitMetrics(provider)
 }

--- a/pkg/reconciler/tls/secrets.go
+++ b/pkg/reconciler/tls/secrets.go
@@ -134,11 +134,11 @@ func (c *Controller) observeCertificateIssuanceDuration(kctx cluster.ObjectMappe
 	// FIXME: refactor the certificate management so that metrics reflect actual state transitions rather than client requests, and so that it's possible to observe issuance errors
 	hostname := kctx.Host()
 	// The certificate request has successfully completed
-	tlsCertificateRequestTotal.WithLabelValues(issuer, hostname, resultLabelSucceeded).Inc()
+	tlsCertificateRequestTotal.WithLabelValues(issuer, resultLabelSucceeded).Inc()
 	// The certificate request has successfully completed so there is one less pending request
 	tls.CertificateRequestCount.WithLabelValues(issuer, hostname).Dec()
 
 	tlsCertificateIssuanceDuration.
-		WithLabelValues(issuer, hostname, resultLabelSucceeded).
+		WithLabelValues(issuer, resultLabelSucceeded).
 		Observe(creationTimestamp.Sub(kctx.CreationTimestamp().Time).Seconds())
 }

--- a/pkg/tls/metrics.go
+++ b/pkg/tls/metrics.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	issuerLabel = "issuer"
-	hostLabel   = "host"
+	issuerLabel   = "issuer"
+	hostnameLabel = "hostname"
 )
 
 var (
@@ -36,7 +36,7 @@ var (
 		},
 		[]string{
 			issuerLabel,
-			hostLabel,
+			hostnameLabel,
 		},
 	)
 )


### PR DESCRIPTION
This PR removes the `hostname` label from the TLS certificate metrics, except for the `glbc_tls_certificate_pending_request_count` metric.

This is a pre-requisite for #145.