### PR TITLE
Update README for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,12 @@ make local-setup
 This script will:
 
 - build all the binaries
-- deploy two kubernetes 1.18 clusters locally.
+- deploy two kubernetes 1.22 clusters locally using `kind`.
 - deploy and configure the ingress controllers in each cluster.
 - start the KCP server.
 
-Once the script is done, open a new terminal, and from the root of the project, you should start the ingress controller:
-
-```bash
-./bin/kcp-glbc --kubeconfig .kcp/admin.kubeconfig --glbc-kubeconfig ./tmp/kcp-cluster-glbc-control.kubeconfig
-```
+Once the script is done, copy the `Run locally:` command from the output.
+Open a new terminal, and from the root of the project, run the copied command.
 
 Now you can create a new ingress resource from the root of the project:
 
@@ -29,29 +26,30 @@ Now you can create a new ingress resource from the root of the project:
 export KUBECONFIG=.kcp/admin.kubeconfig
 kubectl create namespace default
 
-# Multi cluster
-kubectl apply -n default -f samples/echo-service-multi-cluster/echo.yaml
-kubectl apply -n default -f samples/echo-service-multi-cluster/ingress.yaml
+# Single cluster
+kubectl apply -n default -f samples/echo-service/echo.yaml
+```
 
-# single cluster
-kubectl apply -n default -f samples/echo-service-single-cluster/echo.yaml
-kubectl apply -n default -f samples/echo-service-single-cluster/ingress.yaml
+To verify the resources were created successfully, check the output of the following:
+
+```bash
+kubectl get deployment,service,ingress
 ```
 
 If errors are encountered about resources not existing, sometimes deleting the clusters from KCP and recreating them can solve the problem:
 
 Delete the clusters:
 ```bash 
-KUBECONFIG=.kcp/admin.kubeconfig kubectl delete cluster kcp-cluster-1
-KUBECONFIG=.kcp/admin.kubeconfig kubectl delete cluster kcp-cluster-2
+kubectl delete workloadcluster kcp-cluster-1
+kubectl delete workloadcluster kcp-cluster-2
 ```
 Recreate them:
 ```bash
-KUBECONFIG=.kcp/admin.kubeconfig kubectl apply -f ./tmp/kcp-cluster-1.yaml
-KUBECONFIG=.kcp/admin.kubeconfig kubectl apply -f ./tmp/kcp-cluster-2.yaml
+kubectl apply -f ./tmp/kcp-cluster-1.yaml
+kubectl apply -f ./tmp/kcp-cluster-2.yaml
 ```
 
-### Add CRC cluster
+### Add CRC cluster (optional)
 
 With a running local setup i.e. you have successfully executed `make local-setup`, you can run the following to create and add a CRC cluster:
 
@@ -60,7 +58,7 @@ With a running local setup i.e. you have successfully executed `make local-setup
 ```
 
 ```bash
-$ kubectl get clusters -o wide
+$ kubectl get workloadclusters -o wide
 NAME              LOCATION          READY   SYNCED API RESOURCES
 kcp-cluster-1     kcp-cluster-1     True    ["deployments.apps","ingresses.networking.k8s.io","secrets","services"]
 kcp-cluster-2     kcp-cluster-2     True    ["deployments.apps","ingresses.networking.k8s.io","secrets","services"]
@@ -71,6 +69,15 @@ You must have crc installed(https://crc.dev/crc/), and have your openshift pull 
 Please check the script comments for any version requirements.
 
 ## Development
+
+### Interacting directly with WorkloadClusters
+
+Prefix `kubectl` with the appropriate kubeconfig file from the tmp directory.
+For example:
+
+```bash
+KUBECONFIG=./tmp/kcp-cluster-1.kubeconfig kubectl get deployments,services,ingress --all-namespaces
+```
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,6 @@ To verify the resources were created successfully, check the output of the follo
 kubectl get deployment,service,ingress
 ```
 
-If errors are encountered about resources not existing, sometimes deleting the clusters from KCP and recreating them can solve the problem:
-
-Delete the clusters:
-```bash 
-kubectl delete workloadcluster kcp-cluster-1
-kubectl delete workloadcluster kcp-cluster-2
-```
-Recreate them:
-```bash
-kubectl apply -f ./tmp/kcp-cluster-1.yaml
-kubectl apply -f ./tmp/kcp-cluster-2.yaml
-```
-
 ### Add CRC cluster (optional)
 
 With a running local setup i.e. you have successfully executed `make local-setup`, you can run the following to create and add a CRC cluster:


### PR DESCRIPTION
I've suggested some README updates based on trying to get a local dev environment setup.
Hopefully they make sense.

* Update the version of k8s that gets created, and say that it uses `kind` (I thought it needed `crc` and was confused when crc showed nothing running, then got further confused when debugging why podman was having trouble from `crc`, but was actually a problem with `kind`)
* Removed the cmd to run kcp-glbc locally as it's included in the make output, and is more accurate and means 1 less place to keep it up to date (was already out of date in the README)
* Updated the echo example to reference the actual sample file in the repo
* Removed unnecessary KUBECONFIG setting in cmds (it's instructed earlier to export it, so no need to set it for each cmd)
* Marked the section for adding a crc section as optional. My understanding is that it's optional, but that wasn't my first impression and only came to that conclusion after I got things working without it (I didn't have enough RAM to bring 1 up). (It also seems odd to mix crc & kind, unless there's a reason I'm unaware of for having a crc cluster?). 
* Updated CRD name to workloadclusters
* Added a local dev section for how to interact with the data plane clusters created by `kind`.