### PR TITLE
Delete metric from the in-memory registry when the associated ingress…

### DIFF
--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -350,6 +350,7 @@ func TestMetrics(t *testing.T) {
 	))
 
 	// The other metrics should not be updated
+	// and the metric for the deleted ingress is no longer returned
 	test.Consistently(Metrics(test.Ctx()), 15*time.Second).Should(And(
 		HaveKey("glbc_tls_certificate_pending_request_count"),
 		WithTransform(Metric("glbc_tls_certificate_pending_request_count"), EqualP(
@@ -358,15 +359,6 @@ func TestMetrics(t *testing.T) {
 				Help: stringP("GLBC TLS certificate pending request count"),
 				Type: metricTypeP(prometheus.MetricType_GAUGE),
 				Metric: []*prometheus.Metric{
-					{
-						Label: []*prometheus.LabelPair{
-							label("hostname", hostname),
-							label("issuer", issuer),
-						},
-						Gauge: &prometheus.Gauge{
-							Value: float64P(0),
-						},
-					},
 					{
 						Label: []*prometheus.LabelPair{
 							label("hostname", domain),

--- a/pkg/tls/cert_manager.go
+++ b/pkg/tls/cert_manager.go
@@ -164,6 +164,10 @@ func (cm *certManager) Create(ctx context.Context, cr CertificateRequest) error 
 func (cm *certManager) Delete(ctx context.Context, cr CertificateRequest) error {
 	// delete the certificate and delete the secrets
 	certNotFound := false
+
+	// remove metrics with matching labels
+	CertificateRequestCount.DeleteLabelValues(cm.IssuerID(), cr.Host())
+
 	if err := cm.certClient.Certificates(cm.certificateNS).Delete(ctx, cr.Name(), metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err


### PR DESCRIPTION
… cert has been deleted

I'm not sure how big a problem this is or will be, so I'm proposing a change to have the discussion.
Currently whenever a certificate is deleted, the `glbc_tls_certificate_pending_request_count` metric with a host label for that cert continues to exist in memory (and is included in the metrics endpoint) for as long as the process is running.
Restarting the process resets the metrics registry and the metric no longer exists with those labels.

This may become a problem if the number of certificates (and subsequently number of hosts labels) is going to be quite large.
1. The first possible problem is ever increasing memory of the glbc itself, until it's restarted and the registry resets (kind of like a memory leak)
2. The second possible problem is the knock on effect in prometheus where the metrics series will live for longer in some db. (cardinality problems - https://www.robustperception.io/cardinality-is-key)

There's a little more context in https://github.com/prometheus/client_golang/issues/296 as well.

All this being said, if we don't expect the number of hosts to be excessively large, it's not a major problem.
In that case, changing nothing is probably fine.