### PR TITLE
Update grafana dashboard ns dropdown

### DIFF
--- a/config/observability/grafana/dashboards/glbc.yaml
+++ b/config/observability/grafana/dashboards/glbc.yaml
@@ -432,11 +432,7 @@ spec:
         "list": [
           {
             "allValue": null,
-            "current": {
-              "selected": true,
-              "text": "kcp-glbc-stable",
-              "value": "kcp-glbc-stable"
-            },
+            "current": {},
             "datasource": null,
             "definition": "label_values(namespace)",
             "description": null,
@@ -446,33 +442,12 @@ spec:
             "label": "Namespace",
             "multi": false,
             "name": "namespace",
-            "options": [
-              {
-                "selected": false,
-                "text": "kcp-glbc-monitoring",
-                "value": "kcp-glbc-monitoring"
-              },
-              {
-                "selected": false,
-                "text": "kcp-glbc-observability",
-                "value": "kcp-glbc-observability"
-              },
-              {
-                "selected": true,
-                "text": "kcp-glbc-stable",
-                "value": "kcp-glbc-stable"
-              },
-              {
-                "selected": false,
-                "text": "kcp-glbc-unstable",
-                "value": "kcp-glbc-unstable"
-              }
-            ],
+            "options": [],
             "query": {
               "query": "label_values(namespace)",
               "refId": "StandardVariableQuery"
             },
-            "refresh": 0,
+            "refresh": 1,
             "regex": "/^kcp-glbc.*/",
             "skipUrlSync": false,
             "sort": 0,


### PR DESCRIPTION
Update the grafana dashboard "namespace" variable dropdown to remove hard coded options and current selection. Set refresh to 1 (On Dashboard Load).

Test locally with:

**Terminal 1:**
```
make local-setup
```

**Terminal 2:**
```
./utils/local-setup-deploy-glbc.sh
```
http://grafana.127.0.0.1.nip.io:8083
![image](https://user-images.githubusercontent.com/327352/169087415-3573eda1-c81b-4157-a9fc-fc41ada7156a.png)
