### PR TITLE
Remove hostname label from glbc_tls_certificate_pending_request_count…

### DIFF
--- a/docs/observability/monitoring.adoc
+++ b/docs/observability/monitoring.adoc
@@ -221,7 +221,7 @@ The KCP GLBC monitoring endpoint exposes the metrics listed in the following sec
 | `glbc_tls_certificate_pending_request_count`
 | `GaugeVec`
 | Current number of pending certificate requests
-| `issuer`, `hostname`
+| `issuer`
 
 | `glbc_tls_certificate_request_total`
 | `CounterVec`

--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -47,7 +47,6 @@ import (
 	. "github.com/kuadrant/kcp-glbc/e2e/support"
 	kuadrantv1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
 	kuadrantcluster "github.com/kuadrant/kcp-glbc/pkg/cluster"
-	"github.com/kuadrant/kcp-glbc/pkg/util/env"
 )
 
 const issuer = "glbc-ca"
@@ -106,7 +105,6 @@ func TestMetrics(t *testing.T) {
 	test.Expect(err).NotTo(HaveOccurred())
 
 	hostname := ""
-	domain := env.GetEnvString("GLBC_DOMAIN", "hcpapps.net")
 
 	// We pull the metrics aggressively as the certificate can be issued quickly when using the CA issuer.
 	// We may want to adjust the pull interval as well as the timeout based on the configured issuer.
@@ -127,20 +125,10 @@ func TestMetrics(t *testing.T) {
 					Metric: []*prometheus.Metric{
 						{
 							Label: []*prometheus.LabelPair{
-								label("hostname", hostname),
 								label("issuer", issuer),
 							},
 							Gauge: &prometheus.Gauge{
 								Value: float64P(1),
-							},
-						},
-						{
-							Label: []*prometheus.LabelPair{
-								label("hostname", domain),
-								label("issuer", issuer),
-							},
-							Gauge: &prometheus.Gauge{
-								Value: float64P(0),
 							},
 						},
 					},
@@ -193,16 +181,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", hostname),
-							label("issuer", issuer),
-						},
-						Gauge: &prometheus.Gauge{
-							Value: float64P(0),
-						},
-					},
-					{
-						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 						},
 						Gauge: &prometheus.Gauge{
@@ -360,16 +338,6 @@ func TestMetrics(t *testing.T) {
 				Metric: []*prometheus.Metric{
 					{
 						Label: []*prometheus.LabelPair{
-							label("hostname", hostname),
-							label("issuer", issuer),
-						},
-						Gauge: &prometheus.Gauge{
-							Value: float64P(0),
-						},
-					},
-					{
-						Label: []*prometheus.LabelPair{
-							label("hostname", domain),
 							label("issuer", issuer),
 						},
 						Gauge: &prometheus.Gauge{

--- a/pkg/reconciler/tls/secrets.go
+++ b/pkg/reconciler/tls/secrets.go
@@ -132,11 +132,10 @@ func (c *Controller) ensureMirrored(ctx context.Context, kctx cluster.ObjectMapp
 
 func (c *Controller) observeCertificateIssuanceDuration(kctx cluster.ObjectMapper, creationTimestamp metav1.Time, issuer string) {
 	// FIXME: refactor the certificate management so that metrics reflect actual state transitions rather than client requests, and so that it's possible to observe issuance errors
-	hostname := kctx.Host()
 	// The certificate request has successfully completed
 	tlsCertificateRequestTotal.WithLabelValues(issuer, resultLabelSucceeded).Inc()
 	// The certificate request has successfully completed so there is one less pending request
-	tls.CertificateRequestCount.WithLabelValues(issuer, hostname).Dec()
+	tls.CertificateRequestCount.WithLabelValues(issuer).Dec()
 
 	tlsCertificateIssuanceDuration.
 		WithLabelValues(issuer, resultLabelSucceeded).

--- a/pkg/tls/cert_manager.go
+++ b/pkg/tls/cert_manager.go
@@ -157,13 +157,14 @@ func (cm *certManager) Create(ctx context.Context, cr CertificateRequest) error 
 		return err
 	}
 	// TODO: Move to Certificate informer add handler
-	CertificateRequestCount.WithLabelValues(cm.IssuerID(), cr.Host()).Inc()
+	CertificateRequestCount.WithLabelValues(cm.IssuerID()).Inc()
 	return nil
 }
 
 func (cm *certManager) Delete(ctx context.Context, cr CertificateRequest) error {
 	// delete the certificate and delete the secrets
 	certNotFound := false
+
 	if err := cm.certClient.Certificates(cm.certificateNS).Delete(ctx, cr.Name(), metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
@@ -178,7 +179,7 @@ func (cm *certManager) Delete(ctx context.Context, cr CertificateRequest) error 
 			// The Secret does not exist, which indicates the TLS certificate request is still pending,
 			// so we must account for decreasing the number of pending requests.
 			// TODO: Move to Certificate informer delete handler
-			CertificateRequestCount.WithLabelValues(cm.IssuerID(), cr.Host()).Dec()
+			CertificateRequestCount.WithLabelValues(cm.IssuerID()).Dec()
 		}
 	}
 	return nil

--- a/pkg/tls/metrics.go
+++ b/pkg/tls/metrics.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	issuerLabel   = "issuer"
-	hostnameLabel = "hostname"
+	issuerLabel = "issuer"
 )
 
 var (
@@ -36,7 +35,6 @@ var (
 		},
 		[]string{
 			issuerLabel,
-			hostnameLabel,
 		},
 	)
 )
@@ -51,7 +49,5 @@ func init() {
 func InitMetrics(provider Provider) {
 	// Initialize metrics
 	issuer := provider.IssuerID()
-	for _, domain := range provider.Domains() {
-		CertificateRequestCount.WithLabelValues(issuer, domain).Set(0)
-	}
+	CertificateRequestCount.WithLabelValues(issuer).Set(0)
 }


### PR DESCRIPTION
… metric

Fixes #157 

With this change there's 1 metric series per issuer rather than per issuer/hostname combinations.
An example metric & labels looks like this after the change
```
glbc_tls_certificate_pending_request_count{
  container="manager",
  endpoint="metrics",
  instance="10.244.0.29:8080",
  issuer="letsencryptstaging",
  job="kcp-glbc/kcp-glbc-controller-manager",
  namespace="kcp-glbc",
  pod="kcp-glbc-controller-manager-6754bcf5fc-92vxf"
}
```

Note that this change doesn't modify any grafana dashboards.
There is [1 existing query in a panel](https://github.com/Kuadrant/kcp-glbc/blob/999a2f47f67bae06adc6c3c493d24df454f4d292/config/observability/grafana/dashboards/glbc.yaml#L188) I found, which should still work.
However, it could be written more simply e.g. with a `sum_over_time` https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
(I'm also unsure if summing by issuer would always give the desired result in a singlestat panel in cases where there is more than 1 issuer, if that's possible)