### PR TITLE
Organise the dashboard into rows, based on area & USE or RED method

### DIFF
--- a/config/observability/grafana/dashboards/glbc.yaml
+++ b/config/observability/grafana/dashboards/glbc.yaml
@@ -24,12 +24,24 @@ spec:
       "gnetId": null,
       "graphTooltip": 1,
       "id": 2,
-      "iteration": 1652876738193,
+      "iteration": 1653329864718,
       "links": [],
       "panels": [
         {
           "datasource": null,
-          "description": "",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 15,
+          "title": "AWS Route53 - Requests, Errors & Duration (RED Method)",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "description": "Shows aggregate data on DNS requests to AWS Route53 for the selected time range.\nNote that if a different DNS provider than Route53 is used, these values may be 0.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -51,25 +63,28 @@ spec:
             "overrides": []
           },
           "gridPos": {
-            "h": 9,
-            "w": 12,
+            "h": 7,
+            "w": 4,
             "x": 0,
-            "y": 0
+            "y": 1
           },
           "id": 2,
           "options": {
             "colorMode": "value",
             "graphMode": "area",
             "justifyMode": "auto",
-            "orientation": "auto",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
               ],
               "fields": "",
-              "values": false
+              "values": true
             },
-            "text": {},
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
             "textMode": "auto"
           },
           "pluginVersion": "7.5.15",
@@ -100,119 +115,12 @@ spec:
           "type": "stat"
         },
         {
-          "datasource": null,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "green",
-                "mode": "fixed"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 0
-          },
-          "id": 7,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "7.5.15",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (issuer)",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total  {{issuer}}",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Succeeded {{issuer}}",
-              "refId": "B"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Failed {{issuer}}",
-              "refId": "C"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Secrets {{issuer}}",
-              "refId": "D"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Pending {{issuer}}",
-              "refId": "E"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (issuer) - sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total > 5m {{issuer}}",
-              "refId": "F"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "TLS Cert Requests",
-          "type": "stat"
-        },
-        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
+          "description": "Shows aggregate data on DNS requests to AWS Route53 for the selected time range.\nNote that if a different DNS provider than Route53 is used, these values may be 0.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -221,12 +129,12 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 9
+            "w": 20,
+            "x": 4,
+            "y": 1
           },
           "hiddenSeries": false,
-          "id": 4,
+          "id": 10,
           "legend": {
             "avg": false,
             "current": false,
@@ -254,25 +162,18 @@ spec:
           "targets": [
             {
               "exemplar": true,
-              "expr": "kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"memory\"}",
-              "interval": "",
-              "legendFormat": "Pod Memory Requests",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\"}",
+              "expr": "sum(increase(glbc_aws_route53_request_total{namespace=\"$namespace\"}[$__range]))",
               "hide": false,
               "interval": "",
-              "legendFormat": "Pod Memory Limits",
+              "legendFormat": "Total Requests",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "container_memory_rss{namespace=\"$namespace\", container=\"manager\"}  ",
+              "expr": "sum(increase(glbc_aws_route53_request_errors_total{namespace=\"$namespace\"}[$__range]))",
               "hide": false,
               "interval": "",
-              "legendFormat": "Container Memory",
+              "legendFormat": "Total Errors",
               "refId": "B"
             }
           ],
@@ -280,7 +181,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Memory",
+          "title": "AWS Route53 Requests",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -296,11 +197,11 @@ spec:
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "none",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -318,11 +219,89 @@ spec:
           }
         },
         {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 13,
+          "panels": [],
+          "title": "TLS Certificates - Requests, Errors & Duration (RED Method)",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "description": "The identifier of the certificate issuer configured for the controller in the selected namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "rgb(245, 242, 214)",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 0,
+            "y": 10
+          },
+          "id": 9,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "name"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "glbc_tls_certificate_secret_count{namespace=\"$namespace\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{issuer}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TLS Cert Issuer",
+          "type": "stat"
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
+          "description": "Shows aggregate data on certificate requests for the selected time range.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -331,9 +310,334 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 9
+            "w": 20,
+            "x": 4,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 11,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Succeeded",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Failed",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Secrets",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Pending",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (namespace) - sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total > 5min",
+              "refId": "F"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TLS Cert Requests",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Shows aggregate data on certificate requests for the selected time range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 12
+          },
+          "id": 7,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Succeeded",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Failed",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Secrets",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Pending",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (namespace) - sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total > 5m",
+              "refId": "F"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TLS Cert Requests",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 17,
+          "panels": [],
+          "title": "Pods - Utilisation, Saturation & Errors (USE Method)",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "description": "Shows the number of pods by status in the selected namespace. Note this is an 'Instant' value i.e. it uses the latest value instead of querying over a range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 19
+          },
+          "id": 19,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_pod_status_phase{namespace=\"$namespace\"}) by(phase)",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{phase}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Pod Statuses",
+          "type": "stat"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows pod CPU usage for each pod in the namespace. If set, pod CPU requests and limits are also shown. The legend includes a suffix of the pod name.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 20,
+            "x": 4,
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 6,
@@ -367,7 +671,7 @@ spec:
               "expr": "kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"cpu\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "CPU Limits",
+              "legendFormat": "CPU Limits {{pod}}",
               "refId": "C"
             },
             {
@@ -375,14 +679,14 @@ spec:
               "expr": "kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"cpu\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "CPU Requests",
+              "legendFormat": "CPU Requests {{pod}}",
               "refId": "B"
             },
             {
               "exemplar": true,
               "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[1m])) by (pod)",
               "interval": "",
-              "legendFormat": "CPU Load {{pod}}",
+              "legendFormat": "CPU Usage {{pod}}",
               "refId": "A"
             }
           ],
@@ -406,7 +710,184 @@ spec:
           },
           "yaxes": [
             {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": "1",
+              "min": null,
+              "show": true
+            },
+            {
               "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Shows the number of container restarts (by pod) over the chosen time range for the selected namespace.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 25
+          },
+          "id": 20,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
+            "textMode": "value_and_name"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_status_restarts_total{namespace=\"$namespace\"}) by(pod)",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Container Restarts",
+          "type": "stat"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows pod memory usage in MiB (based on RSS) for each pod in the namespace. If set, pod memory requests and limits are also shown. The legend includes a suffix of the pod name.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 20,
+            "x": 4,
+            "y": 27
+          },
+          "hiddenSeries": false,
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"memory\"}",
+              "interval": "",
+              "legendFormat": "Pod Memory Requests {{pod}}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Pod Memory Limits {{pod}}",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(container_memory_rss{namespace=\"$namespace\", container=\"manager\"}) by (pod)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Pod Memory {{pod}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -436,23 +917,22 @@ spec:
         "list": [
           {
             "allValue": null,
-            "current": {},
             "datasource": null,
-            "definition": "label_values(namespace)",
+            "definition": "label_values(glbc_controller_reconcile_total, namespace)",
             "description": null,
             "error": null,
             "hide": 0,
             "includeAll": false,
-            "label": "Namespace",
+            "label": "Namespace (filtered to glbc namespaces)",
             "multi": false,
             "name": "namespace",
             "options": [],
             "query": {
-              "query": "label_values(namespace)",
+              "query": "label_values(glbc_controller_reconcile_total, namespace)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
-            "regex": "/^kcp-glbc.*/",
+            "regex": "",
             "skipUrlSync": false,
             "sort": 0,
             "tagValuesQuery": "",
@@ -474,5 +954,5 @@ spec:
       "timezone": "browser",
       "title": "GLBC",
       "uid": "75f3d9c692690c6badc848e02a3d6e1b82444622",
-      "version": 6
+      "version": 8
     }


### PR DESCRIPTION
There's a few changes here, so I'll list them and include some before & after screenshots:

* Filter the namespace dropdown to only list namespaces where a glbc is detected (based on the existence of the `glbc_controller_reconcile_total` metric)
* Organise the panels into 3 rows - AWS Route53, TLS & Pods
* Align graphs on each row for easier correlation
* Specify the metrics method used for each row i.e. [USE](https://www.brendangregg.com/usemethod.html#:~:text=The%20Utilization%20Saturation%20and%20Errors,identifying%20resource%20bottlenecks%20or%20errors.) or [RED](https://www.weave.works/blog/the-red-method-key-metrics-for-microservices-architecture/)
* Set the y axis data types better (e.g. MiB, % etc..)
* Move the Cert issuer name out of the stat panel into a separate panel (avoids showing duplicate data)
* Include pod names in memory & cpu graph legends
* Add some extra pod stats to the Resource usage row
* Add tooltips (via descriptions) for all panels
* Update some queries to sum by namespace rather than issuer (as there'll only be 1 issuer per namespace)

Before:
![image](https://user-images.githubusercontent.com/878251/169886117-21ca0f70-b1ec-4048-b3f5-b1fa33789b58.png)


After:
![image](https://user-images.githubusercontent.com/878251/169886147-eec492be-b3b8-4438-b813-3ff4e7d3694f.png)
![image](https://user-images.githubusercontent.com/878251/169886169-75cde5a1-031f-41fb-8684-d2653f6b7c72.png)
