### PR TITLE
Reconcile panels

### DIFF
--- a/config/observability/grafana/dashboards/glbc.yaml
+++ b/config/observability/grafana/dashboards/glbc.yaml
@@ -24,7 +24,7 @@ spec:
       "gnetId": null,
       "graphTooltip": 1,
       "id": 2,
-      "iteration": 1653329864718,
+      "iteration": 1653488916714,
       "links": [],
       "panels": [
         {
@@ -907,6 +907,636 @@ spec:
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows the total number of Goroutines by pod. Only 1 line is expected for the glbc pod.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 20,
+            "x": 4,
+            "y": 35
+          },
+          "hiddenSeries": false,
+          "id": 37,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(go_goroutines{job=\"$namespace/kcp-glbc-controller-manager\"}) by(pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Goroutines",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 43
+          },
+          "id": 30,
+          "panels": [],
+          "title": "Reconciliation & Workers - Requests, Errors & Duration (RED Method)",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows the rate of successful reconcile loops",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "hiddenSeries": false,
+          "id": 32,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(glbc_controller_reconcile_total{job=\"$namespace/kcp-glbc-controller-manager\",result=\"success\"}[5m])) by (controller)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{controller}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Controller Reconcile Rate (success)",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows the rate of resources being queued for processing by each controller.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "hiddenSeries": false,
+          "id": 34,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(workqueue_adds_total{job=\"$namespace/kcp-glbc-controller-manager\"}[5m])) by (instance, name)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} {{name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Work Queue Add Rate",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows the rate of failed/erroring reconcile loops",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "hiddenSeries": false,
+          "id": 33,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(glbc_controller_reconcile_total{job=\"$namespace/kcp-glbc-controller-manager\",result=\"error\"}[5m])) by (controller)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{controller}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Controller Reconcile Rate (error)",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows the queue size for each resource controller.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "hiddenSeries": false,
+          "id": 35,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(workqueue_depth{job=\"$namespace/kcp-glbc-controller-manager\"}[5m])) by (instance, name)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} {{name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Work Queue Depth",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows the queue processing latency for each resource controller.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 58
+          },
+          "hiddenSeries": false,
+          "id": 36,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"$namespace/kcp-glbc-controller-manager\"}[5m])) by (instance, name, le))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} {{name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Work Queue Latency",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "refresh": "5s",
@@ -917,6 +1547,11 @@ spec:
         "list": [
           {
             "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "kcp-glbc",
+              "value": "kcp-glbc"
+            },
             "datasource": null,
             "definition": "label_values(glbc_controller_reconcile_total, namespace)",
             "description": null,
@@ -954,5 +1589,5 @@ spec:
       "timezone": "browser",
       "title": "GLBC",
       "uid": "75f3d9c692690c6badc848e02a3d6e1b82444622",
-      "version": 8
+      "version": 16
     }

--- a/config/observability/grafana/dashboards/glbc.yaml
+++ b/config/observability/grafana/dashboards/glbc.yaml
@@ -24,12 +24,24 @@ spec:
       "gnetId": null,
       "graphTooltip": 1,
       "id": 2,
-      "iteration": 1652876738193,
+      "iteration": 1653329864718,
       "links": [],
       "panels": [
         {
           "datasource": null,
-          "description": "",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 15,
+          "title": "AWS Route53 - Requests, Errors & Duration (RED Method)",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "description": "Shows aggregate data on DNS requests to AWS Route53 for the selected time range.\nNote that if a different DNS provider than Route53 is used, these values may be 0.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -51,25 +63,28 @@ spec:
             "overrides": []
           },
           "gridPos": {
-            "h": 9,
-            "w": 12,
+            "h": 7,
+            "w": 4,
             "x": 0,
-            "y": 0
+            "y": 1
           },
           "id": 2,
           "options": {
             "colorMode": "value",
             "graphMode": "area",
             "justifyMode": "auto",
-            "orientation": "auto",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
               ],
               "fields": "",
-              "values": false
+              "values": true
             },
-            "text": {},
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
             "textMode": "auto"
           },
           "pluginVersion": "7.5.15",
@@ -100,119 +115,12 @@ spec:
           "type": "stat"
         },
         {
-          "datasource": null,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "green",
-                "mode": "fixed"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 0
-          },
-          "id": 7,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "7.5.15",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (issuer)",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total  {{issuer}}",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Succeeded {{issuer}}",
-              "refId": "B"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Failed {{issuer}}",
-              "refId": "C"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Secrets {{issuer}}",
-              "refId": "D"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total Pending {{issuer}}",
-              "refId": "E"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (issuer) - sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (issuer)",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Total > 5m {{issuer}}",
-              "refId": "F"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "TLS Cert Requests",
-          "type": "stat"
-        },
-        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
+          "description": "Shows aggregate data on DNS requests to AWS Route53 for the selected time range.\nNote that if a different DNS provider than Route53 is used, these values may be 0.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -221,12 +129,12 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 9
+            "w": 20,
+            "x": 4,
+            "y": 1
           },
           "hiddenSeries": false,
-          "id": 4,
+          "id": 10,
           "legend": {
             "avg": false,
             "current": false,
@@ -254,25 +162,18 @@ spec:
           "targets": [
             {
               "exemplar": true,
-              "expr": "kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"memory\"}",
-              "interval": "",
-              "legendFormat": "Pod Memory Requests",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\"}",
+              "expr": "sum(increase(glbc_aws_route53_request_total{namespace=\"$namespace\"}[$__range]))",
               "hide": false,
               "interval": "",
-              "legendFormat": "Pod Memory Limits",
+              "legendFormat": "Total Requests",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "container_memory_rss{namespace=\"$namespace\", container=\"manager\"}  ",
+              "expr": "sum(increase(glbc_aws_route53_request_errors_total{namespace=\"$namespace\"}[$__range]))",
               "hide": false,
               "interval": "",
-              "legendFormat": "Container Memory",
+              "legendFormat": "Total Errors",
               "refId": "B"
             }
           ],
@@ -280,7 +181,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Memory",
+          "title": "AWS Route53 Requests",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -296,11 +197,11 @@ spec:
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "none",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -318,11 +219,89 @@ spec:
           }
         },
         {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 13,
+          "panels": [],
+          "title": "TLS Certificates - Requests, Errors & Duration (RED Method)",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "description": "The identifier of the certificate issuer configured for the controller in the selected namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "rgb(245, 242, 214)",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 0,
+            "y": 10
+          },
+          "id": 9,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "name"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "glbc_tls_certificate_secret_count{namespace=\"$namespace\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{issuer}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TLS Cert Issuer",
+          "type": "stat"
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
+          "description": "Shows aggregate data on certificate requests for the selected time range.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -331,9 +310,334 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 9
+            "w": 20,
+            "x": 4,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 11,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Succeeded",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Failed",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Secrets",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Pending",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (namespace) - sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total > 5min",
+              "refId": "F"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TLS Cert Requests",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Shows aggregate data on certificate requests for the selected time range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 12
+          },
+          "id": 7,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Succeeded",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Failed",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Secrets",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Pending",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (namespace) - sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (namespace)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total > 5m",
+              "refId": "F"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TLS Cert Requests",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 17,
+          "panels": [],
+          "title": "Pods - Utilisation, Saturation & Errors (USE Method)",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "description": "Shows the number of pods by status in the selected namespace. Note this is an 'Instant' value i.e. it uses the latest value instead of querying over a range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 19
+          },
+          "id": 19,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_pod_status_phase{namespace=\"$namespace\"}) by(phase)",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{phase}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Pod Statuses",
+          "type": "stat"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows pod CPU usage for each pod in the namespace. If set, pod CPU requests and limits are also shown. The legend includes a suffix of the pod name.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 20,
+            "x": 4,
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 6,
@@ -367,7 +671,7 @@ spec:
               "expr": "kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"cpu\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "CPU Limits",
+              "legendFormat": "CPU Limits {{pod}}",
               "refId": "C"
             },
             {
@@ -375,14 +679,14 @@ spec:
               "expr": "kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"cpu\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "CPU Requests",
+              "legendFormat": "CPU Requests {{pod}}",
               "refId": "B"
             },
             {
               "exemplar": true,
               "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[1m])) by (pod)",
               "interval": "",
-              "legendFormat": "CPU Load {{pod}}",
+              "legendFormat": "CPU Usage {{pod}}",
               "refId": "A"
             }
           ],
@@ -406,7 +710,184 @@ spec:
           },
           "yaxes": [
             {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": "1",
+              "min": null,
+              "show": true
+            },
+            {
               "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Shows the number of container restarts (by pod) over the chosen time range for the selected namespace.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 25
+          },
+          "id": 20,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "titleSize": 18,
+              "valueSize": 18
+            },
+            "textMode": "value_and_name"
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_status_restarts_total{namespace=\"$namespace\"}) by(pod)",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Container Restarts",
+          "type": "stat"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Shows pod memory usage in MiB (based on RSS) for each pod in the namespace. If set, pod memory requests and limits are also shown. The legend includes a suffix of the pod name.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 20,
+            "x": 4,
+            "y": 27
+          },
+          "hiddenSeries": false,
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.15",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"memory\"}",
+              "interval": "",
+              "legendFormat": "Pod Memory Requests {{pod}}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Pod Memory Limits {{pod}}",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(container_memory_rss{namespace=\"$namespace\", container=\"manager\"}) by (pod)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Pod Memory {{pod}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -436,23 +917,22 @@ spec:
         "list": [
           {
             "allValue": null,
-            "current": {},
             "datasource": null,
-            "definition": "label_values(namespace)",
+            "definition": "label_values(glbc_controller_reconcile_total, namespace)",
             "description": null,
             "error": null,
             "hide": 0,
             "includeAll": false,
-            "label": "Namespace",
+            "label": "Namespace (filtered to glbc namespaces)",
             "multi": false,
             "name": "namespace",
             "options": [],
             "query": {
-              "query": "label_values(namespace)",
+              "query": "label_values(glbc_controller_reconcile_total, namespace)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
-            "regex": "/^kcp-glbc.*/",
+            "regex": "",
             "skipUrlSync": false,
             "sort": 0,
             "tagValuesQuery": "",
@@ -474,5 +954,5 @@ spec:
       "timezone": "browser",
       "title": "GLBC",
       "uid": "75f3d9c692690c6badc848e02a3d6e1b82444622",
-      "version": 6
+      "version": 8
     }


### PR DESCRIPTION
Based on #165 (which should merge first and this PR rebased then).
Closes #107 

This change adds a 'Reconciliation and Workers' row with associated panels.
It also includes 1 new panel to show the number of goroutines, placed in the 'Pods' row.

Goroutines panel:
![image](https://user-images.githubusercontent.com/878251/170289589-21d03b4b-24ab-4ffd-8a35-2df284a9b1a9.png)


Reconciliation and Workers row:
![image](https://user-images.githubusercontent.com/878251/170289542-bb4d802f-420d-41cc-866e-879bd2506c2b.png)
