### PR TITLE
Ingress objects metrics

### DIFF
--- a/docs/observability/monitoring.adoc
+++ b/docs/observability/monitoring.adoc
@@ -246,20 +246,16 @@ The KCP GLBC monitoring endpoint exposes the metrics listed in the following sec
 |===
 |Name |Type |Description |Labels
 
-| `glbc_ingress_managed_object_reconciliation`
-| `GaugeVec`
-| Number of managed ingress object reconciliation
-| `workspace`, `namespace`, `ingress name`, `result`
 
 | `glbc_ingress_managed_object_total`
-| `GaugeVec`
+| `Gauge`
 | Total number of managed ingress object
-| `workspace`, `namespace`
+| none
 
 | `glbc_ingress_managed_object_time_to_admission`
-| `HistogramVec`
+| `Histogram`
 | Duration of the ingress object admission
-| `workspace`, `namespace`
+| none
 
 |===
 

--- a/docs/observability/monitoring.adoc
+++ b/docs/observability/monitoring.adoc
@@ -240,6 +240,29 @@ The KCP GLBC monitoring endpoint exposes the metrics listed in the following sec
 
 |===
 
+=== Ingress Object Metrics
+
+.Ingress object metrics
+|===
+|Name |Type |Description |Labels
+
+| `glbc_ingress_managed_object_reconciliation`
+| `GaugeVec`
+| Number of managed ingress object reconciliation
+| `workspace`, `namespace`, `ingress name`, `result`
+
+| `glbc_ingress_managed_object_total`
+| `GaugeVec`
+| Total number of managed ingress object
+| `workspace`, `namespace`
+
+| `glbc_ingress_managed_object_time_to_admission`
+| `HistogramVec`
+| Duration of the ingress object admission
+| `workspace`, `namespace`
+
+|===
+
 === Controller Metrics
 
 .Reconcilation metrics

--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -171,6 +171,25 @@ func TestMetrics(t *testing.T) {
 	metrics, err := getMetrics(test.Ctx())
 	test.Expect(err).NotTo(HaveOccurred())
 
+	// should be managing 1 ingress
+	test.Expect(metrics).To(And(
+		HaveKey("glbc_ingress_managed_object_total"),
+		WithTransform(Metric("glbc_ingress_managed_object_total"), EqualP(
+			prometheus.MetricFamily{
+				Name: stringP("glbc_ingress_managed_object_total"),
+				Help: stringP("Total number of managed ingress object"),
+				Type: metricTypeP(prometheus.MetricType_GAUGE),
+				Metric: []*prometheus.Metric{
+					{
+						Gauge: &prometheus.Gauge{
+							Value: float64P(1),
+						},
+					},
+				},
+			},
+		)),
+	))
+
 	test.Expect(metrics).To(And(
 		HaveKey("glbc_tls_certificate_pending_request_count"),
 		WithTransform(Metric("glbc_tls_certificate_pending_request_count"), EqualP(
@@ -307,7 +326,7 @@ func TestMetrics(t *testing.T) {
 		Delete(test.Ctx(), name, metav1.DeleteOptions{})).
 		To(Succeed())
 
-	// Only the TLS certificate Secret count should change
+	// Only the TLS certificate Secret count and number of ingresses managed should change
 	test.Eventually(Metrics(test.Ctx()), TestTimeoutShort).Should(And(
 		HaveKey("glbc_tls_certificate_secret_count"),
 		WithTransform(Metric("glbc_tls_certificate_secret_count"), MatchFieldsP(IgnoreExtras,
@@ -325,6 +344,21 @@ func TestMetrics(t *testing.T) {
 				}),
 			},
 		)),
+		HaveKey("glbc_ingress_managed_object_total"),
+		WithTransform(Metric("glbc_ingress_managed_object_total"), EqualP(
+			prometheus.MetricFamily{
+				Name: stringP("glbc_ingress_managed_object_total"),
+				Help: stringP("Total number of managed ingress object"),
+				Type: metricTypeP(prometheus.MetricType_GAUGE),
+				Metric: []*prometheus.Metric{
+					{
+						Gauge: &prometheus.Gauge{
+							Value: float64P(0),
+						},
+					},
+				},
+			}),
+		),
 	))
 
 	// The other metrics should not be updated

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -57,9 +57,18 @@ func NewController(config *ControllerConfig) *Controller {
 
 	// Watch for events related to Ingresses
 	c.sharedInformerFactory.Networking().V1().Ingresses().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.Enqueue(obj) },
+		AddFunc: func(obj interface{}) {
+			ingress := obj.(*networkingv1.Ingress)
+			initMetrics(ingress)
+			ingressObjectTotal.WithLabelValues(ingress.ClusterName, ingress.Namespace).Inc()
+			c.Enqueue(obj)
+		},
 		UpdateFunc: func(_, obj interface{}) { c.Enqueue(obj) },
-		DeleteFunc: func(obj interface{}) { c.Enqueue(obj) },
+		DeleteFunc: func(obj interface{}) {
+			ingress := obj.(*networkingv1.Ingress)
+			ingressObjectTotal.WithLabelValues(ingress.ClusterName, ingress.Namespace).Dec()
+			c.Enqueue(obj)
+		},
 	})
 
 	// Watch for events related to Services
@@ -118,6 +127,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 
 	err = c.reconcile(ctx, current)
 	if err != nil {
+		ingressObjectReconcilationTotal.WithLabelValues(current.ClusterName, current.Namespace, current.Name, resultLabelFailed).Inc()
 		return err
 	}
 
@@ -125,6 +135,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		_, err := c.kubeClient.Cluster(logicalcluster.From(current)).NetworkingV1().Ingresses(current.Namespace).Update(ctx, current, metav1.UpdateOptions{})
 		return err
 	}
+	ingressObjectReconcilationTotal.WithLabelValues(current.ClusterName, current.Namespace, current.Name, resultLabelSucceeded).Inc()
 
 	return nil
 }

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -166,7 +166,6 @@ func (c *Controller) ensureDNS(ctx context.Context, ingress *networkingv1.Ingres
 
 			// metric to observe the ingress admission time
 			ingressObjectTimeToAdmission.
-				WithLabelValues(ingress.ClusterName, ingress.Namespace).
 				Observe(existing.CreationTimestamp.Time.Sub(ingress.CreationTimestamp.Time).Seconds())
 
 		} else if err == nil {

--- a/pkg/reconciler/ingress/metrics.go
+++ b/pkg/reconciler/ingress/metrics.go
@@ -1,0 +1,75 @@
+package ingress
+
+import (
+	"time"
+
+	"github.com/kuadrant/kcp-glbc/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+const (
+	ingressWorkspace     = "workspace"
+	ingressNamespace     = "namespace"
+	ingressName          = "name"
+	resultLabel          = "result"
+	resultLabelSucceeded = "succeeded"
+	resultLabelFailed    = "failed"
+)
+
+var (
+	ingressObjectTimeToAdmission = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "glbc_ingress_managed_object_time_to_admission",
+			Help: "Duration of the ingress object admission",
+			Buckets: []float64{
+				1 * time.Second.Seconds(),
+				5 * time.Second.Seconds(),
+				10 * time.Second.Seconds(),
+				15 * time.Second.Seconds(),
+				30 * time.Second.Seconds(),
+				45 * time.Second.Seconds(),
+				1 * time.Minute.Seconds(),
+				2 * time.Minute.Seconds(),
+				5 * time.Minute.Seconds(),
+			},
+		},
+		[]string{
+			ingressWorkspace,
+			ingressNamespace,
+		})
+
+	ingressObjectTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "glbc_ingress_managed_object_total",
+			Help: "Total number of managed ingress object",
+		}, []string{
+			ingressWorkspace,
+			ingressNamespace,
+		})
+
+	ingressObjectReconcilationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "glbc_ingress_managed_object_reconciliation",
+			Help: "Number of managed ingress object reconciliation",
+		}, []string{
+			ingressWorkspace,
+			ingressNamespace,
+			ingressName,
+			resultLabel,
+		})
+)
+
+func init() {
+	// Register metrics with the global prometheus registry
+	metrics.Registry.MustRegister(
+		ingressObjectTimeToAdmission,
+		ingressObjectTotal,
+		ingressObjectReconcilationTotal,
+	)
+}
+
+func initMetrics(ingress *networkingv1.Ingress) {
+	ingressObjectReconcilationTotal.WithLabelValues(ingress.ClusterName, ingress.Namespace, ingress.Name, resultLabelSucceeded).Add(0)
+	ingressObjectReconcilationTotal.WithLabelValues(ingress.ClusterName, ingress.Namespace, ingress.Name, resultLabelFailed).Add(0)
+}

--- a/pkg/reconciler/ingress/metrics.go
+++ b/pkg/reconciler/ingress/metrics.go
@@ -5,20 +5,10 @@ import (
 
 	"github.com/kuadrant/kcp-glbc/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	networkingv1 "k8s.io/api/networking/v1"
-)
-
-const (
-	ingressWorkspace     = "workspace"
-	ingressNamespace     = "namespace"
-	ingressName          = "name"
-	resultLabel          = "result"
-	resultLabelSucceeded = "succeeded"
-	resultLabelFailed    = "failed"
 )
 
 var (
-	ingressObjectTimeToAdmission = prometheus.NewHistogramVec(
+	ingressObjectTimeToAdmission = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name: "glbc_ingress_managed_object_time_to_admission",
 			Help: "Duration of the ingress object admission",
@@ -33,30 +23,12 @@ var (
 				2 * time.Minute.Seconds(),
 				5 * time.Minute.Seconds(),
 			},
-		},
-		[]string{
-			ingressWorkspace,
-			ingressNamespace,
 		})
 
-	ingressObjectTotal = prometheus.NewGaugeVec(
+	ingressObjectTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "glbc_ingress_managed_object_total",
 			Help: "Total number of managed ingress object",
-		}, []string{
-			ingressWorkspace,
-			ingressNamespace,
-		})
-
-	ingressObjectReconcilationTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "glbc_ingress_managed_object_reconciliation",
-			Help: "Number of managed ingress object reconciliation",
-		}, []string{
-			ingressWorkspace,
-			ingressNamespace,
-			ingressName,
-			resultLabel,
 		})
 )
 
@@ -65,11 +37,5 @@ func init() {
 	metrics.Registry.MustRegister(
 		ingressObjectTimeToAdmission,
 		ingressObjectTotal,
-		ingressObjectReconcilationTotal,
 	)
-}
-
-func initMetrics(ingress *networkingv1.Ingress) {
-	ingressObjectReconcilationTotal.WithLabelValues(ingress.ClusterName, ingress.Namespace, ingress.Name, resultLabelSucceeded).Add(0)
-	ingressObjectReconcilationTotal.WithLabelValues(ingress.ClusterName, ingress.Namespace, ingress.Name, resultLabelFailed).Add(0)
 }


### PR DESCRIPTION
Adds metrics around managed ingress objects 

~- glbc_ingress_managed_object_reconciliation(namespace, workspace, result, name)~
- glbc_ingress_managed_object_total ~(namespace, workspace)~
- glbc_ingress_managed_object_time_to_admission ~(namespace, workspace)~

**UPDATE**: We are removing the reconciliation metric (glbc_ingress_managed_object_reconciliation) as this can be achieved via the [controller metrics](https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/monitoring.adoc#controller-metrics) and removing the `namespace` and `workspace` as we are trying to get a more global view for now.

Closes: https://github.com/Kuadrant/kcp-glbc/issues/106

## Verification steps

1) Install GLBC locally 
`make local-setup`
2) Create an ingress object against KCP 
`kubectl apply -n default -f samples/echo-service/echo.yaml`
3) Verify the metrics are exposed
```
curl http://localhost:8080/metrics | grep "glbc_ingress_managed"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 42477    0 42477    0     0  4609k      0 --:--:-- --:--:-- --:--:-- 4609k
# HELP glbc_ingress_managed_object_time_to_admission Duration of the ingress object admission
# TYPE glbc_ingress_managed_object_time_to_admission histogram
glbc_ingress_managed_object_time_to_admission_bucket{le="1"} 0
glbc_ingress_managed_object_time_to_admission_bucket{le="5"} 0
glbc_ingress_managed_object_time_to_admission_bucket{le="10"} 1
glbc_ingress_managed_object_time_to_admission_bucket{le="15"} 1
glbc_ingress_managed_object_time_to_admission_bucket{le="30"} 3
glbc_ingress_managed_object_time_to_admission_bucket{le="45"} 3
glbc_ingress_managed_object_time_to_admission_bucket{le="60"} 3
glbc_ingress_managed_object_time_to_admission_bucket{le="120"} 3
glbc_ingress_managed_object_time_to_admission_bucket{le="300"} 3
glbc_ingress_managed_object_time_to_admission_bucket{le="+Inf"} 3
glbc_ingress_managed_object_time_to_admission_sum 58
glbc_ingress_managed_object_time_to_admission_count 3
# HELP glbc_ingress_managed_object_total Total number of managed ingress object
# TYPE glbc_ingress_managed_object_total gauge
glbc_ingress_managed_object_total 3
```
