### PR TITLE
chore(e2e): Mark support functions as test helper functions

### DIFF
--- a/e2e/support/deployment.go
+++ b/e2e/support/deployment.go
@@ -14,6 +14,7 @@ import (
 )
 
 func GetDeployments(t Test, namespace *corev1.Namespace, labelSelector string) []appsv1.Deployment {
+	t.T().Helper()
 	return Deployments(t, namespace, labelSelector)(t)
 }
 

--- a/e2e/support/dns.go
+++ b/e2e/support/dns.go
@@ -15,6 +15,7 @@ import (
 )
 
 func GetDNSRecord(t Test, namespace *corev1.Namespace, name string) *kuadrantv1.DNSRecord {
+	t.T().Helper()
 	return DNSRecord(t, namespace, name)(t)
 }
 

--- a/e2e/support/ingress.go
+++ b/e2e/support/ingress.go
@@ -30,6 +30,7 @@ import (
 )
 
 func GetIngress(t Test, namespace *corev1.Namespace, name string) *networkingv1.Ingress {
+	t.T().Helper()
 	return Ingress(t, namespace, name)(t)
 }
 
@@ -42,6 +43,7 @@ func Ingress(t Test, namespace *corev1.Namespace, name string) func(g gomega.Gom
 }
 
 func GetIngresses(t Test, namespace *corev1.Namespace, labelSelector string) []networkingv1.Ingress {
+	t.T().Helper()
 	return Ingresses(t, namespace, labelSelector)(t)
 }
 

--- a/e2e/support/secret.go
+++ b/e2e/support/secret.go
@@ -29,6 +29,7 @@ import (
 )
 
 func GetSecret(t Test, namespace *corev1.Namespace, name string) *corev1.Secret {
+	t.T().Helper()
 	return Secret(t, namespace, name)(t)
 }
 

--- a/e2e/support/service.go
+++ b/e2e/support/service.go
@@ -13,6 +13,7 @@ import (
 )
 
 func GetServices(t Test, namespace *corev1.Namespace, labelSelector string) []corev1.Service {
+	t.T().Helper()
 	return Services(t, namespace, labelSelector)(t)
 }
 


### PR DESCRIPTION
This enables to report the stack traces in the assertion error messages more accurately.