### PR TITLE
fix: Enqueue Ingresses on Namespace updates

### DIFF
--- a/e2e/ingress_test.go
+++ b/e2e/ingress_test.go
@@ -118,8 +118,8 @@ func TestIngress(t *testing.T) {
 
 	// Update the namespace with the second cluster placement
 	_, err = test.Client().Core().Cluster(logicalcluster.From(namespace)).CoreV1().Namespaces().Apply(test.Ctx(), corev1apply.Namespace(namespace.Name).WithLabels(map[string]string{kcp.ClusterLabel: cluster2.Name}), ApplyOptions)
-
 	test.Expect(err).NotTo(HaveOccurred())
+
 	// Wait until the Ingress is reconciled with the load balancer Ingresses
 	test.Eventually(Ingress(test, namespace, name)).WithTimeout(TestTimeoutMedium).Should(And(
 		WithTransform(Annotations, HaveKey(kuadrantcluster.ANNOTATION_HCG_HOST)),


### PR DESCRIPTION
This PR makes sure changes on the namespace, such as an update of the KCP cluster label,  `workloads.kcp.dev/cluster`, are reflected by the Ingress controller, into the Ingresses within that namespace.

It fixes a flake in the Ingress e2e test, where the following expectation is not consistently satisfied without the fix: https://github.com/Kuadrant/kcp-glbc/blob/1c6cdd748c5d1f1e9010b320b8ea35087e33e4b5/e2e/ingress_test.go#L127