### PR TITLE
Use a rate for the graph showing time ranges

### DIFF
--- a/config/observability/grafana/dashboards/glbc.yaml
+++ b/config/observability/grafana/dashboards/glbc.yaml
@@ -41,7 +41,7 @@ spec:
         },
         {
           "datasource": null,
-          "description": "Shows aggregate data on DNS requests to AWS Route53 for the selected time range.\nNote that if a different DNS provider than Route53 is used, these values may be 0.",
+          "description": "Shows the rate of requests to Route53 for the selected time range. Note that if a different DNS provider than Route53 is used, these values may be 0.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -91,7 +91,7 @@ spec:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_aws_route53_request_total{namespace=\"$namespace\"}[$__range]))",
+              "expr": "sum(rate(glbc_aws_route53_request_total{namespace=\"$namespace\"}[$__range]))",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -101,7 +101,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_aws_route53_request_errors_total{namespace=\"$namespace\"}[$__range]))",
+              "expr": "sum(rate(glbc_aws_route53_request_errors_total{namespace=\"$namespace\"}[$__range]))",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -301,7 +301,7 @@ spec:
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
-          "description": "Shows aggregate data on certificate requests for the selected time range.",
+          "description": "Shows the rate of certificate requests for the selected time range.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -343,7 +343,7 @@ spec:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "expr": "sum(rate(glbc_tls_certificate_request_total{namespace=\"$namespace\"}[$__range])) by (namespace)",
               "hide": false,
               "interval": "",
               "legendFormat": "Total",
@@ -351,7 +351,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(namespace)",
+              "expr": "sum(rate(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"succeeded\"}[$__range])) by(namespace)",
               "hide": false,
               "interval": "",
               "legendFormat": "Total Succeeded",
@@ -359,7 +359,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (namespace)",
+              "expr": "sum(rate(glbc_tls_certificate_request_total{namespace=\"$namespace\", result=\"failed\"}[$__range])) by (namespace)",
               "hide": false,
               "interval": "",
               "legendFormat": "Total Failed",
@@ -367,7 +367,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (namespace)",
+              "expr": "sum(rate(glbc_tls_certificate_secret_count{namespace=\"$namespace\" }[$__range])) by (namespace)",
               "hide": false,
               "interval": "",
               "legendFormat": "Total Secrets",
@@ -375,7 +375,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (namespace)",
+              "expr": "sum(rate(glbc_tls_certificate_pending_request_count{namespace=\"$namespace\"}[$__range])) by (namespace)",
               "hide": false,
               "interval": "",
               "legendFormat": "Total Pending",
@@ -383,7 +383,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (namespace) - sum(increase(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (namespace)",
+              "expr": "sum(rate(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\", le=\"+Inf\"}[$__range])) by (namespace) - sum(rate(glbc_tls_certificate_issuance_duration_seconds_bucket{namespace=\"$namespace\" , le=\"300\"}[$__range]))  by (namespace)",
               "hide": false,
               "interval": "",
               "legendFormat": "Total > 5min",


### PR DESCRIPTION
This was a small oversight on my part I noticed when I went back to demo the dashboard.

The 2 time range graphs for route53 requests & tls certs should show a per second rate rather than the increase of the time range.
The change will result in much smaller numbers (as it's per second rates) on the 2 panels.
Tooltip text is also updated.

![image](https://user-images.githubusercontent.com/878251/171445174-35c4c410-91c9-4b08-8ae6-140d889023a6.png)
