### PR TITLE
fix: Avoid updating TLS Secrets unnecessarily

### DIFF
--- a/pkg/reconciler/tls/controller.go
+++ b/pkg/reconciler/tls/controller.go
@@ -51,9 +51,7 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 			}
 			c.Enqueue(obj)
 		},
-		UpdateFunc: func(_, obj interface{}) {
-			c.Enqueue(obj)
-		},
+		UpdateFunc: func(old, obj interface{}) { c.Enqueue(obj) },
 		DeleteFunc: func(obj interface{}) {
 			secret := obj.(*corev1.Secret)
 			issuer, hasIssuer := secret.Annotations[tlsIssuerAnnotation]


### PR DESCRIPTION
Pre-requisite for #194.

This fixes an infinite reconciliation loop in the Secret controller, where the Secret being reconciled is always updated and re-enqueued.