### PR TITLE
e2e: Wait for DNSRecord reconciliation before idling assertion

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -166,6 +166,8 @@ jobs:
 
           GLBC_LOG_FILE="${TEMP_DIR}"/glbc.log
           echo "GLBC_LOG_FILE=${GLBC_LOG_FILE}" >> $GITHUB_ENV
+          export AWS_DNS_PUBLIC_ZONE_ID=FAKE_ZONE_ID
+          echo "AWS_DNS_PUBLIC_ZONE_ID=FAKE_ZONE_ID" >> $GITHUB_ENV
           echo "Starting GLBC, sending logs to ${GLBC_LOG_FILE}"
           ./bin/kcp-glbc --kubeconfig .kcp/admin.kubeconfig --context system:admin --glbc-kubeconfig "${HOME}"/.kube/config --dns-provider fake --glbc-tls-provided true > ${GLBC_LOG_FILE} 2>&1 &
           GLBC_PID=$!
@@ -182,6 +184,7 @@ jobs:
         run: |
           export KUBECONFIG=${{ env.KUBECONFIG }}
           export CLUSTERS_KUBECONFIG_DIR=${{ env.CLUSTERS_KUBECONFIG_DIR }}
+          export AWS_DNS_PUBLIC_ZONE_ID=${{ env.AWS_DNS_PUBLIC_ZONE_ID }}
 
           # Then run e2e tests
           make e2e

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,9 @@ test: generate ## Run tests.
 
 .PHONY: e2e
 e2e: build
-	## Run the metrics test first, so it's start from a clean state
+	## Run the metrics test first, so it starts from a clean state
 	KUBECONFIG="$(KUBECONFIG)" CLUSTERS_KUBECONFIG_DIR="$(CLUSTERS_KUBECONFIG_DIR)" \
+	AWS_DNS_PUBLIC_ZONE_ID="${AWS_DNS_PUBLIC_ZONE_ID}" \
 	go test -timeout 60m -v ./e2e/metrics -tags=e2e
 	## Run the other tests
 	KUBECONFIG="$(KUBECONFIG)" CLUSTERS_KUBECONFIG_DIR="$(CLUSTERS_KUBECONFIG_DIR)" \

--- a/e2e/support/dns.go
+++ b/e2e/support/dns.go
@@ -30,3 +30,20 @@ func DNSRecord(t Test, namespace *corev1.Namespace, name string) func(g gomega.G
 func DNSRecordEndpoints(record *kuadrantv1.DNSRecord) []*kuadrantv1.Endpoint {
 	return record.Spec.Endpoints
 }
+
+func DNSRecordCondition(zoneID, condition string) func(record *kuadrantv1.DNSRecord) *kuadrantv1.DNSZoneCondition {
+	return func(record *kuadrantv1.DNSRecord) *kuadrantv1.DNSZoneCondition {
+		for _, z := range record.Status.Zones {
+			if z.DNSZone.ID != zoneID {
+				continue
+			}
+			for _, c := range z.Conditions {
+				if c.Type == condition {
+					return &c
+				}
+			}
+			return nil
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This PR follows up #194 to fix #180, by making sure we reach the final reconciliation state before asserting no spurious reconciliation occurs.