### PR TITLE
fix: Do not enqueue resource updates without semantic changes

### DIFF
--- a/pkg/reconciler/tls/controller.go
+++ b/pkg/reconciler/tls/controller.go
@@ -51,7 +51,11 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 			}
 			c.Enqueue(obj)
 		},
-		UpdateFunc: func(old, obj interface{}) { c.Enqueue(obj) },
+		UpdateFunc: func(old, obj interface{}) {
+			if old.(*corev1.Secret).ResourceVersion != obj.(*corev1.Secret).ResourceVersion {
+				c.Enqueue(obj)
+			}
+		},
 		DeleteFunc: func(obj interface{}) {
 			secret := obj.(*corev1.Secret)
 			issuer, hasIssuer := secret.Annotations[tlsIssuerAnnotation]


### PR DESCRIPTION
This PR follows up #195 to fix #180.