### PR TITLE
fix: Do not enqueue DNSRecord when its generation hasn't incremented

### DIFF
--- a/pkg/reconciler/dns/controller.go
+++ b/pkg/reconciler/dns/controller.go
@@ -53,8 +53,12 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 	c.dnsZones = dnsZones
 
 	c.sharedInformerFactory.Kuadrant().V1().DNSRecords().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.Enqueue(obj) },
-		UpdateFunc: func(_, obj interface{}) { c.Enqueue(obj) },
+		AddFunc: func(obj interface{}) { c.Enqueue(obj) },
+		UpdateFunc: func(old, obj interface{}) {
+			if old.(*v1.DNSRecord).Generation != obj.(*v1.DNSRecord).Generation {
+				c.Enqueue(obj)
+			}
+		},
 		DeleteFunc: func(obj interface{}) { c.Enqueue(obj) },
 	})
 


### PR DESCRIPTION
This PR follows up #195 and #203, to fix #180.

The DNSRecord controller should only reconciler changes to the DNSRecord spec, and avoid re-enqueue the same DNSRecord after its status sub-resource has been updated.