### PR TITLE
Closes #108. Enable metrics in client-go for rest requests

### DIFF
--- a/docs/observability/generated_metrics.adoc
+++ b/docs/observability/generated_metrics.adoc
@@ -49,6 +49,12 @@ and the 2nd column is the table title (e.g. "Go Runtime Metrics")
 | `workqueue_unfinished_work_seconds` | How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.| GAUGE| `name` 
 | `workqueue_work_duration_seconds` | How long in seconds processing an item from workqueue takes.| HISTOGRAM| `name` 
 |===
+.client-go REST API Call metrics
+|===
+|Name |Help |Type |Labels
+| `rest_client_request_latency_seconds` | Request latency in seconds. Broken down by verb.| HISTOGRAM| `verb` 
+| `rest_client_requests_total` | Number of HTTP requests, partitioned by status code, method, and host.| COUNTER| `code` `host` `method` 
+|===
 .Go Runtime metrics
 |===
 |Name |Help |Type |Labels

--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -87,6 +87,10 @@ func TestMetrics(t *testing.T) {
 				"Metric": ContainElement(certificateSecretCount(issuer, 0)),
 			},
 		)),
+		// Client go rest metrics should exist
+		// Asserting actual values may cause flakes, so just existence will suffice
+		HaveKey("rest_client_request_latency_seconds"),
+		HaveKey("rest_client_requests_total"),
 		// glbc_tls_certificate_issuance_duration_seconds
 		// histogram vector are not initialized
 		Not(HaveKey("glbc_tls_certificate_issuance_duration_seconds")),

--- a/pkg/metrics/client_go_adapter.go
+++ b/pkg/metrics/client_go_adapter.go
@@ -1,0 +1,91 @@
+// This file is originally based on https://github.com/kubernetes-sigs/controller-runtime/blob/f46919744bee01060c9084a285e049afffd38c9d/pkg/metrics/client_go_adapter.go
+// which uses the same license as this project (Apache License Version 2.0)
+// It is stripped down to provide request result & latency metrics for rest client usage.
+// There used to be reflector metrics in client-go, however they were removed due to a
+// memory leak: https://github.com/kubernetes/kubernetes/pull/74636
+// That PR also has some discussion about the usefulness of reflector metrics.
+// If any additional metrics (existing or new) in client-go need to be exposed, they can
+// be registered and a provider set in this file
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+)
+
+// this file contains setup logic to initialize the myriad of places
+// that client-go registers metrics.  We copy the names and formats
+// from Kubernetes so that we match the core controllers.
+
+// Metrics subsystem and all of the keys used by the rest client.
+const (
+	RestClientSubsystem = "rest_client"
+	LatencyKey          = "request_latency_seconds"
+	ResultKey           = "requests_total"
+)
+
+var (
+	// client metrics.
+
+	// To prevent cardinality explosion, only the verb is added as a label to latency metrics
+	RequestLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: RestClientSubsystem,
+		Name:      LatencyKey,
+		Help:      "Request latency in seconds. Broken down by verb.",
+		Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10),
+	}, []string{"verb"})
+
+	requestResult = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: RestClientSubsystem,
+		Name:      ResultKey,
+		Help:      "Number of HTTP requests, partitioned by status code, method, and host.",
+	}, []string{"code", "method", "host"})
+)
+
+func init() {
+	registerClientMetrics()
+}
+
+// registerClientMetrics sets up the client latency metrics from client-go.
+func registerClientMetrics() {
+	// register the metrics with our registry
+	Registry.MustRegister(requestResult)
+	Registry.MustRegister(RequestLatency)
+
+	// register the metrics with client-go
+	clientmetrics.Register(clientmetrics.RegisterOpts{
+		RequestResult:  &resultAdapter{metric: requestResult},
+		RequestLatency: &LatencyAdapter{metric: RequestLatency},
+	})
+}
+
+// this section contains adapters, implementations, and other sundry organic, artisanally
+// hand-crafted syntax trees required to convince client-go that it actually wants to let
+// someone use its metrics.
+
+// Client metrics adapters (method #1 for client-go metrics),
+// copied (more-or-less directly) from k8s.io/kubernetes setup code
+// (which isn't anywhere in an easily-importable place).
+
+// LatencyAdapter implements LatencyMetric.
+type LatencyAdapter struct {
+	metric *prometheus.HistogramVec
+}
+
+// Observe increments the request latency metric for the given verb/URL.
+func (l *LatencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
+	l.metric.WithLabelValues(verb).Observe(latency.Seconds())
+}
+
+type resultAdapter struct {
+	metric *prometheus.CounterVec
+}
+
+func (r *resultAdapter) Increment(_ context.Context, code, method, host string) {
+	r.metric.WithLabelValues(code, method, host).Inc()
+}

--- a/utils/prometheus_format_tables.csv
+++ b/utils/prometheus_format_tables.csv
@@ -4,5 +4,6 @@ glbc_controller_,Reconcilation metrics
 glbc_ingress_,Ingress object metrics
 glbc_tls_certificate_,TLS certificate metrics
 workqueue_,Workqueue metrics
+rest_client_,client-go REST API Call metrics
 go_,Go Runtime metrics
 process_,Process metrics


### PR DESCRIPTION
2 new metrics:
- rest_client_request_latency_seconds histogram
- rest_client_requests_total counter

TODO:
- [x] e2e test
- [x] update monitoring docs after/if #205 lands
