### PR TITLE
Add admission rate & fix percentiles

### DIFF
--- a/config/observability/grafana/dashboards/glbc.yaml
+++ b/config/observability/grafana/dashboards/glbc.yaml
@@ -24,7 +24,7 @@ spec:
       "gnetId": null,
       "graphTooltip": 1,
       "id": 2,
-      "iteration": 1653488916714,
+      "iteration": 1654686081619,
       "links": [],
       "panels": [
         {
@@ -46,29 +46,29 @@ spec:
           "description": "Shows the total number of managed ingress objects",
           "fieldConfig": {
             "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-              {
-                "color": "green",
-                "value": null
+              "color": {
+                "mode": "thresholds"
               },
-              {
-                "color": "red",
-                "value": 80
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
               }
-              ]
-            }
             },
             "overrides": []
           },
           "gridPos": {
             "h": 2,
-            "w": 5,
+            "w": 4,
             "x": 0,
             "y": 1
           },
@@ -79,27 +79,27 @@ spec:
             "justifyMode": "auto",
             "orientation": "horizontal",
             "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
             },
             "text": {
-            "titleSize": 18,
-            "valueSize": 18
+              "titleSize": 18,
+              "valueSize": 18
             },
             "textMode": "auto"
           },
           "pluginVersion": "7.5.15",
           "targets": [
             {
-            "exemplar": true,
-            "expr": "sum(glbc_ingress_managed_object_total)",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "A"
+              "exemplar": true,
+              "expr": "sum(glbc_ingress_managed_object_total)",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
             }
           ],
           "title": "Total Ingress objects",
@@ -111,7 +111,7 @@ spec:
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
-          "description": "Shows average time of the ingress objects to be admitted in the load balance",
+          "description": "Shows the Ingress admission rate to load balancers, and the 90, 95 & 99th percentiles for how long admissions took.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -119,9 +119,9 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 6,
-            "w": 18,
-            "x": 5,
+            "h": 7,
+            "w": 20,
+            "x": 4,
             "y": 1
           },
           "hiddenSeries": false,
@@ -133,7 +133,7 @@ spec:
             "max": false,
             "min": false,
             "rightSide": false,
-            "show": false,
+            "show": true,
             "total": false,
             "values": false
           },
@@ -148,24 +148,57 @@ spec:
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "Admission Rate",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-            "exemplar": true,
-            "expr": "histogram_quantile(0.9, sum(rate(glbc_ingress_managed_object_time_to_admission_bucket[5m])))",
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
+              "exemplar": true,
+              "expr": "sum(rate(glbc_ingress_managed_object_time_to_admission_count[5m]))",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Admission Rate",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.9, sum  by(le) (rate(glbc_ingress_managed_object_time_to_admission_bucket[$__range])))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "90th %ile",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(glbc_ingress_managed_object_time_to_admission_bucket[$__range])))",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "95th %ile",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, sum by(le) (rate(glbc_ingress_managed_object_time_to_admission_bucket[$__range])))",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "99th %ile",
+              "refId": "D"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Average time to ingress admission",
+          "title": "Ingress Admissions",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -181,21 +214,19 @@ spec:
           },
           "yaxes": [
             {
-              "$$hashKey": "object:182",
               "format": "s",
-              "label": null,
+              "label": "Admission time",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
-              "$$hashKey": "object:183",
-              "format": "s",
-              "label": null,
+              "format": "none",
+              "label": "Admissions/sec",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ],
@@ -210,7 +241,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 8
           },
           "id": 15,
           "title": "AWS Route53 - Requests, Errors & Duration (RED Method)",
@@ -243,7 +274,7 @@ spec:
             "h": 7,
             "w": 4,
             "x": 0,
-            "y": 8
+            "y": 9
           },
           "id": 2,
           "options": {
@@ -308,7 +339,7 @@ spec:
             "h": 8,
             "w": 20,
             "x": 4,
-            "y": 8
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 10,
@@ -402,7 +433,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 16
+            "y": 17
           },
           "id": 13,
           "panels": [],
@@ -438,7 +469,7 @@ spec:
             "h": 2,
             "w": 4,
             "x": 0,
-            "y": 17
+            "y": 18
           },
           "id": 9,
           "options": {
@@ -489,7 +520,7 @@ spec:
             "h": 8,
             "w": 20,
             "x": 4,
-            "y": 17
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 11,
@@ -635,7 +666,7 @@ spec:
             "h": 6,
             "w": 4,
             "x": 0,
-            "y": 19
+            "y": 20
           },
           "id": 7,
           "options": {
@@ -726,7 +757,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 25
+            "y": 26
           },
           "id": 17,
           "panels": [],
@@ -762,7 +793,7 @@ spec:
             "h": 6,
             "w": 4,
             "x": 0,
-            "y": 26
+            "y": 27
           },
           "id": 19,
           "options": {
@@ -814,7 +845,7 @@ spec:
             "h": 8,
             "w": 20,
             "x": 4,
-            "y": 26
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 6,
@@ -937,7 +968,7 @@ spec:
             "h": 6,
             "w": 4,
             "x": 0,
-            "y": 32
+            "y": 33
           },
           "id": 20,
           "options": {
@@ -991,7 +1022,7 @@ spec:
             "h": 8,
             "w": 20,
             "x": 4,
-            "y": 34
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 4,
@@ -1104,7 +1135,7 @@ spec:
             "h": 8,
             "w": 20,
             "x": 4,
-            "y": 42
+            "y": 43
           },
           "hiddenSeries": false,
           "id": 37,
@@ -1195,7 +1226,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 50
+            "y": 51
           },
           "id": 30,
           "panels": [],
@@ -1221,7 +1252,7 @@ spec:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 32,
@@ -1323,7 +1354,7 @@ spec:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 34,
@@ -1426,7 +1457,7 @@ spec:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 33,
@@ -1528,7 +1559,7 @@ spec:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 35,
@@ -1631,7 +1662,7 @@ spec:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 36,
@@ -1724,11 +1755,6 @@ spec:
         "list": [
           {
             "allValue": null,
-            "current": {
-              "selected": false,
-              "text": "kcp-glbc",
-              "value": "kcp-glbc"
-            },
             "datasource": null,
             "definition": "label_values(glbc_controller_reconcile_total, namespace)",
             "description": null,
@@ -1766,5 +1792,5 @@ spec:
       "timezone": "browser",
       "title": "GLBC",
       "uid": "75f3d9c692690c6badc848e02a3d6e1b82444622",
-      "version": 16
+      "version": 1
     }


### PR DESCRIPTION
@jjaferson I've made a few tweaks from your PR #209 for you to review (I didn't want to just push to your PR branch without getting your take on them first).

- fix the percentile query to sum by the `le` label. If we don't do this, the query sums all buckets together and results in no percentiles at all (as no le labels were left in the result set to calculate percentiles with)
- add a right y axis that also shows the admission rate/s. The intention is to allow easier correlation between increases in percentiles and the rate of ingresses being admitted
- expanded the graph to show 3x percentiles i.e. 90, 95 & 99, to better catch outliers vs. a general increase across the board
- updated tooltip text to represent the above changes
- aligned the singlestat & graph with the panels below them

Here's a screenshot with a small amount of sample data
![image](https://user-images.githubusercontent.com/878251/172605564-91c9349f-3a7b-456f-aa8f-0ea1c57160d8.png)
