### PR TITLE
Add SLI/SLO proposal

### DIFF
--- a/docs/observability/service_level_indicators_and_objectives.adoc
+++ b/docs/observability/service_level_indicators_and_objectives.adoc
@@ -1,0 +1,17 @@
+= Service Level Indicators and Objectives
+
+NOTE: The thresholds for indicators and objectives are intended as examples. Tweak them to suit your service availability needs. Make sure to take into account any dependencies on 3rd party services, such as DNS and certificate signing. Your own objectives should *not* aim to be better than the combined agreed level of service of your dependencies.
+
+[cols="1,1,1"]
+|===
+|Category|SLI|SLO
+
+|Ingress Admission Latency
+|The proportion of sufficiently fast Ingress admissions, as measured from ingress creation through to admission time in the gateway. "Sufficiently fast" is defined as < 2 minutes , or < 5 minutes.
+
+Uses histogram_quantile with the `glbc_ingress_managed_object_time_to_admission` histogram type metric.
+|90% of admissions < 2 minutes
+
+95% of admissions < 5 minutes
+|===
+


### PR DESCRIPTION
Closes #185.
It's probably easier to view this change in the adoc rich diff.

This proposal is deliberately for only 1 indicator and objective at this time.
It is focused on the primary job of the controller, and what the user really cares about i.e. an ingress being ready for use.

There is a separate follow up, #186 , to define some alert templates for the objective i.e. a 'symptom based alert'.
However, this doesn't preclude other [cause based alerts](https://docs.google.com/document/d/199PqyG3UsyXlwieHaqbGiWVa8eMWi8zzAn0YfcApr8Q/edit) being added (such as #187 , #188 , #189 ). They work hand in hand.