### PR TITLE
rbac: Add APIExport ClusterRole

### DIFF
--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kcp-glbc-controller-manager
+rules:
+  - apiGroups:
+    - apis.kcp.dev
+    resources:
+      - apiexports
+    verbs:
+      - get
+  - apiGroups:
+    - apis.kcp.dev
+    resources:
+      - apiexports/content
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete

--- a/config/rbac/cluster_role_binding.yaml
+++ b/config/rbac/cluster_role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kcp-glbc-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kcp-glbc-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: kcp-glbc-controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- cluster_role.yaml
+- cluster_role_binding.yaml


### PR DESCRIPTION
Grant the GLBC controller access to APIExport resources and their content sub-resources.

Part of #237.