### PR TITLE
Just patch the deployment image rather than apply the entire resource…

### DIFF
--- a/.github/workflows/kcp-glbc-image.yaml
+++ b/.github/workflows/kcp-glbc-image.yaml
@@ -77,6 +77,5 @@ jobs:
         id: deploy-image
         run: |-
           export PATH="${PATH}:$(pwd)/bin/"
-          (cd config/manager && kustomize edit set image controller=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/kcp-glbc:${{ needs.build.outputs.sha_short }})
-          kustomize build config/manager
-          kustomize build config/manager | kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} apply -f -
+          export CONTROLLER_IMAGE=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/kcp-glbc:${{ needs.build.outputs.sha_short }})
+          kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} patch deployment kcp-glbc-controller-manager --patch '{"spec": {"template": {"spec": {"containers": [{"name": "manager","image": "$CONTROLLER_IMAGE"}]}}}}'


### PR DESCRIPTION
… and potentially undoing a change

This avoids undoing any kustomize changes that were applied during initial install e.g. extra labels on the deployment or container template.
Changing the image to the sha will have the same effect as before i.e. deploying the latest image
