### PR TITLE
Fix kcp-glbc-image workflow

### DIFF
--- a/.github/workflows/kcp-glbc-image.yaml
+++ b/.github/workflows/kcp-glbc-image.yaml
@@ -19,12 +19,17 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
+      controller_image: ${{ steps.vars-image.outputs.controller_image }}
     steps:
       - uses: actions/checkout@v2
 
       - name: Get the short sha
         id: vars
         run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
+
+      - name: Get the controller image
+        id: vars-image
+        run: echo "::set-output name=controller_image::${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/kcp-glbc:${{ steps.vars.outputs.sha_short }}"
 
       - name: Add short sha tag
         id: add-sha-tag
@@ -64,8 +69,6 @@ jobs:
     environment: unstable
     runs-on: ubuntu-20.04
     needs: build
-    env:
-      CONTROLLER_IMAGE: "${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/kcp-glbc:${{ needs.build.outputs.sha_short }}"
     steps:
       - uses: actions/checkout@v2
       - name: Set up kubectl and kustomize
@@ -79,5 +82,5 @@ jobs:
         id: deploy-image
         run: |-
           export PATH="${PATH}:$(pwd)/bin/"
-          echo "Controller image: ${{ env.CONTROLLER_IMAGE }}"
-          kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} patch deployment kcp-glbc-controller-manager --patch '{"spec": {"template": {"spec": {"containers": [{"name": "manager","image": "${{ env.CONTROLLER_IMAGE }}" }]}}}}'
+          echo "Controller Image: ${{ needs.build.outputs.controller_image }}"
+          kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} patch deployment kcp-glbc-controller-manager --patch '{"spec": {"template": {"spec": {"containers": [{"name": "manager","image": "${{ needs.build.outputs.controller_image }}"}]}}}}'


### PR DESCRIPTION
Output controller image from build job.

Tested here https://github.com/Kuadrant/kcp-glbc/actions/runs/2616729402, so more confident it should actually work this time.