### PR TITLE
fix: Do not pollute working queues with staled objects

### DIFF
--- a/pkg/reconciler/dns/controller.go
+++ b/pkg/reconciler/dns/controller.go
@@ -85,7 +85,7 @@ type Controller struct {
 }
 
 func (c *Controller) process(ctx context.Context, key string) error {
-	dnsRecord, exists, err := c.indexer.GetByKey(key)
+	object, exists, err := c.indexer.GetByKey(key)
 	if err != nil {
 		return err
 	}
@@ -95,15 +95,15 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		return nil
 	}
 
-	current := dnsRecord.(*v1.DNSRecord)
-	previous := current.DeepCopy()
+	current := object.(*v1.DNSRecord)
+	target := current.DeepCopy()
 
-	if err = c.reconcile(ctx, current); err != nil {
+	if err = c.reconcile(ctx, target); err != nil {
 		return err
 	}
 
-	if !equality.Semantic.DeepEqual(previous, current) {
-		_, err := c.dnsRecordClient.Cluster(logicalcluster.From(current)).KuadrantV1().DNSRecords(current.Namespace).Update(ctx, current, metav1.UpdateOptions{})
+	if !equality.Semantic.DeepEqual(current, target) {
+		_, err := c.dnsRecordClient.Cluster(logicalcluster.From(target)).KuadrantV1().DNSRecords(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
 		return err
 	}
 

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -55,7 +55,7 @@ type Controller struct {
 }
 
 func (c *Controller) process(ctx context.Context, key string) error {
-	service, exists, err := c.indexer.GetByKey(key)
+	object, exists, err := c.indexer.GetByKey(key)
 	if err != nil {
 		return err
 	}
@@ -65,15 +65,15 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		return nil
 	}
 
-	current := service.(*corev1.Service)
-	previous := current.DeepCopy()
+	current := object.(*corev1.Service)
+	target := current.DeepCopy()
 
-	if err = c.reconcile(ctx, current); err != nil {
+	if err = c.reconcile(ctx, target); err != nil {
 		return err
 	}
 
-	if !equality.Semantic.DeepEqual(previous, current) {
-		_, err := c.coreClient.Cluster(logicalcluster.From(current)).CoreV1().Services(current.Namespace).Update(ctx, current, metav1.UpdateOptions{})
+	if !equality.Semantic.DeepEqual(current, target) {
+		_, err := c.coreClient.Cluster(logicalcluster.From(target)).CoreV1().Services(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
 		return err
 	}
 


### PR DESCRIPTION
Currently, objects from the work queues are directly passed for reconciliation. This leads to polluting the work queues with staled objects in case of reconciliation errors, which breaks update event handlers on subsequent reconciliations / retries.

This PR makes sure objects copies are passed during reconciliation of objects from the work queues.