### PR TITLE
e2e: TLS certificate issuance duration can be rounded to zero

### DIFF
--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -57,7 +57,7 @@ func TestMetrics(t *testing.T) {
 		// glbc_ingress_managed_object_time_to_admission
 		HaveKey("glbc_ingress_managed_object_time_to_admission"),
 		WithTransform(Metric("glbc_ingress_managed_object_time_to_admission"), EqualP(
-			ingressManagedObjectTimeToAdmission(0, 0),
+			ingressManagedObjectTimeToAdmission(0, -1),
 		)),
 		// glbc_tls_certificate_pending_request_count
 		HaveKey("glbc_tls_certificate_pending_request_count"),
@@ -326,7 +326,7 @@ func ingressManagedObjectTimeToAdmission(count uint64, duration float64) prometh
 			{
 				Histogram: &prometheus.Histogram{
 					SampleCount: uint64P(count),
-					SampleSum:   float64P(duration),
+					SampleSum:   positiveFloat64P(duration),
 					Bucket: buckets(duration, []float64{
 						1 * time.Second.Seconds(),
 						5 * time.Second.Seconds(),
@@ -422,7 +422,7 @@ func certificateIssuanceDurationSeconds(issuer string, count uint64, duration fl
 				},
 				Histogram: &prometheus.Histogram{
 					SampleCount: uint64P(count),
-					SampleSum:   float64P(duration),
+					SampleSum:   positiveFloat64P(duration),
 					Bucket: buckets(duration, []float64{
 						1 * time.Second.Seconds(),
 						5 * time.Second.Seconds(),

--- a/e2e/metrics/support.go
+++ b/e2e/metrics/support.go
@@ -97,7 +97,7 @@ func label(name, value string) *prometheus.LabelPair {
 
 func bucket(value float64, upperBound float64) *prometheus.Bucket {
 	var count uint64
-	if value > 0 && value <= upperBound {
+	if value >= 0 && value <= upperBound {
 		count++
 	}
 	return &prometheus.Bucket{
@@ -127,5 +127,12 @@ func uint64P(i uint64) *uint64 {
 }
 
 func float64P(f float64) *float64 {
+	return &f
+}
+
+func positiveFloat64P(f float64) *float64 {
+	if f < 0 {
+		return float64P(0)
+	}
 	return &f
 }


### PR DESCRIPTION
This PR is part of improving the stability of the metrics e2e test. It turns out the certificate issuance can be very quick when using the CA issuer, which leads to a duration that's rounded to zero.