### PR TITLE
fix: TLS certificate issuance duration on update conflicts

### DIFF
--- a/pkg/reconciler/tls/secrets.go
+++ b/pkg/reconciler/tls/secrets.go
@@ -113,13 +113,13 @@ func (c *Controller) ensureMirrored(ctx context.Context, kctx cluster.ObjectMapp
 		if !k8errors.IsAlreadyExists(err) {
 			return err
 		}
-		s, err := secretClient.Get(ctx, mirror.Name, metav1.GetOptions{})
+		mirrored, err = secretClient.Get(ctx, mirror.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		mirror.ResourceVersion = s.ResourceVersion
-		mirror.UID = s.UID
-		if _, err := secretClient.Update(ctx, mirror, metav1.UpdateOptions{}); err != nil {
+		mirror.ResourceVersion = mirrored.ResourceVersion
+		mirror.UID = mirrored.UID
+		if _, err = secretClient.Update(ctx, mirror, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR fixes the observation of the TLS certificate issuance duration metric, that is currently based on a staled Secret object when the Ingress update request fails because of conflicts. This PR makes sure the Secret object is the updated one.