### PR TITLE
Allow multi cluster aware option to be set to false.

### DIFF
--- a/utils/create_glbc_ns.sh
+++ b/utils/create_glbc_ns.sh
@@ -103,8 +103,6 @@ if [ "$CLUSTER_ROLE" = true ] ; then
   kubectl apply -f ${KCP_GLBC_DIR}/config/kcp/glbc-cluster-role.yaml
   kubectl apply -f ${KCP_GLBC_DIR}/config/kcp/glbc-cluster-role-binding.yaml
 else
-  kubectl delete -f ${KCP_GLBC_DIR}/config/kcp/glbc-cluster-role.yaml
-  kubectl delete -f ${KCP_GLBC_DIR}/config/kcp/glbc-cluster-role-binding.yaml
   ## Create ns/role/rolebinding and serviceAccount for user
   cd config/kcp/ || exit
   ../../bin/kustomize edit set namespace $namespace

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -169,7 +169,7 @@ deploy_glbc_observability() {
 # Script Start                                             #
 ############################################################
 
-while getopts "c:k:mn:hw:W:" arg; do
+while getopts "c:k:m:n:hw:W:" arg; do
   case "${arg}" in
     c)
       DEPLOY_COMPONENTS=${OPTARG}
@@ -178,7 +178,7 @@ while getopts "c:k:mn:hw:W:" arg; do
       GLBC_KUSTOMIZATION=${OPTARG}
       ;;
     m)
-      MULTI_WORKSPACE_AWARE=true
+      MULTI_WORKSPACE_AWARE=${OPTARG}
       ;;
     n)
       GLBC_NAMESPACE=${OPTARG}


### PR DESCRIPTION
The default value of MULTI_WORKSPACE_AWARE was changed to true to work correctly  with local-setup, but it wasn't possible to specify false. Can now be done with:

```
./utils/deploy.sh -m false
```

Removes the deletion of cluster roles and role bindings from `utils/create_glbc_ns.sh` 