### PR TITLE
High DNS Errors Alerts

### DIFF
--- a/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -35,3 +35,12 @@ spec:
           for: "5m"
           labels:
             severity: critical
+        - alert: HighDNSProviderErrorRate
+          annotations:
+            description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSProviderErrorRate.adoc
+            summary: High DNS Provider Error Rate
+          expr: "sum(rate(glbc_aws_route53_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_aws_route53_request_total{}[5m])) by(pod) > 0.01"
+          for: "60m"
+          labels:
+            severity: warning

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -37,7 +37,7 @@ spec:
             severity: critical
         - alert: HighDNSLatencyAlert
           annotations:
-            description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+            description: "High latency rate when requesting DNS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
             runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
             summary: High DNS Latency Rate Alert
           expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -35,6 +35,15 @@ spec:
           for: "5m"
           labels:
             severity: critical
+        - alert: HighDNSLatencyAlert
+          annotations:
+            description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
+            summary: High DNS Latency Rate Alert
+          expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"
+          for: "60m"
+          labels:
+            severity: warning
         - alert: HighDNSProviderErrorRate
           annotations:
             description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
@@ -28,3 +28,12 @@ groups:
         for: "5m"
         labels:
           severity: critical
+      - alert: HighDNSProviderErrorRate
+        annotations:
+          description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSProviderErrorRate.adoc
+          summary: High DNS Provider Error Rate
+        expr: "sum(rate(glbc_aws_route53_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_aws_route53_request_total{}[5m])) by(pod) > 0.01"
+        for: "60m"
+        labels:
+          severity: warning

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
@@ -30,7 +30,7 @@ groups:
           severity: critical
       - alert: HighDNSLatencyAlert
         annotations:
-          description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+          description: "High latency rate when requesting DNS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
           runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
           summary: High DNS Latency Rate Alert
         expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
@@ -28,6 +28,15 @@ groups:
         for: "5m"
         labels:
           severity: critical
+      - alert: HighDNSLatencyAlert
+        annotations:
+          description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
+          summary: High DNS Latency Rate Alert
+        expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"
+        for: "60m"
+        labels:
+          severity: warning
       - alert: HighDNSProviderErrorRate
         annotations:
           description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSLatencyAlert_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSLatencyAlert_test.yaml
@@ -1,0 +1,25 @@
+rule_files:
+  - ../rules-glbc.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: glbc_aws_route53_request_duration_seconds_sum{pod="glbc"}
+        values: "0+0x60 1+10x65"
+      - series: glbc_aws_route53_request_duration_seconds_count{pod="glbc"}
+        values: "0+0x60 1+1x65"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: HighDNSLatencyAlert
+        exp_alerts: []
+      - eval_time: 125m
+        alertname: HighDNSLatencyAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: 'Summary of the alert'
+              description: 'More detailed description of the alert and cause of firing'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc'

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSLatencyAlert_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSLatencyAlert_test.yaml
@@ -20,6 +20,6 @@ tests:
           - exp_labels:
               severity: warning
             exp_annotations:
-              summary: 'Summary of the alert'
-              description: 'More detailed description of the alert and cause of firing'
+              summary: 'High DNS Latency Rate Alert'
+              description: 'High latency rate when requesting DNS - The latency rate is 0.6000000000000001 seconds, which is greater than our threshold which is 0.5seconds.'
               runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc'

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSLatencyAlert_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSLatencyAlert_test.yaml
@@ -7,9 +7,9 @@ tests:
   - interval: 1m
     input_series:
       - series: glbc_aws_route53_request_duration_seconds_sum{pod="glbc"}
-        values: "0+0x60 1+10x65"
+        values: "0+0x60 0+6x65"
       - series: glbc_aws_route53_request_duration_seconds_count{pod="glbc"}
-        values: "0+0x60 1+1x65"
+        values: "0+0x60 0+10x65"
     alert_rule_test:
       - eval_time: 60m
         alertname: HighDNSLatencyAlert

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSProviderErrorRate_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSProviderErrorRate_test.yaml
@@ -1,0 +1,25 @@
+rule_files:
+  - ../rules-glbc.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: glbc_aws_route53_request_errors_total{pod="glbc"}
+        values: "0+0x60 2+2x65"
+      - series: glbc_aws_route53_request_total{pod="glbc"}
+        values: "100+100x125"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: HighDNSProviderErrorRate
+        exp_alerts: []
+      - eval_time: 125m
+        alertname: HighDNSProviderErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: 'High DNS Provider Error Rate'
+              description: 'Excessive errors - more than 1% of requests are errors'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSProviderErrorRate.adoc'

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSProviderErrorRate_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighDNSProviderErrorRate_test.yaml
@@ -19,7 +19,8 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
+              pod: glbc
             exp_annotations:
               summary: 'High DNS Provider Error Rate'
-              description: 'Excessive errors - more than 1% of requests are errors'
+              description: 'Excessive errors - The error rate is 0.02, which is greater than the threshold which is 1%'
               runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSProviderErrorRate.adoc'

--- a/config/observability/monitoring_resources/common/rules/HighDNSLatencyAlert.dhall
+++ b/config/observability/monitoring_resources/common/rules/HighDNSLatencyAlert.dhall
@@ -25,7 +25,7 @@ in  PrometheusOperator.Rule::{
         ( toMap
             { summary = "High DNS Latency Rate Alert"
             , description =
-                "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ \$value }}"
+                "High latency rate when requesting DNS - The latency rate is {{ \$value }} seconds, which is greater than our threshold which is 0.5seconds."
             , runbook_url =
                 "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc"
             }

--- a/config/observability/monitoring_resources/common/rules/HighDNSLatencyAlert.dhall
+++ b/config/observability/monitoring_resources/common/rules/HighDNSLatencyAlert.dhall
@@ -1,0 +1,33 @@
+let K8s =
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v6.0.0/package.dhall
+        sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
+
+let TimeUnit = ../../dhall/TimeUnit/package.dhall
+
+let Duration = ../../dhall/Duration/package.dhall
+
+let AlertSeverity = ../../dhall/AlertSeverity/package.dhall
+
+let PrometheusOperator =
+      ( https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v8.0.0/package.dhall
+          sha256:ebc5f0c5f57d410412c2b7cbb64d0883be648eafc094f0c3e10dba4e6bd46ed4
+      ).v1
+
+in  PrometheusOperator.Rule::{
+    , alert = Some "HighDNSLatencyAlert"
+    , expr =
+        K8s.IntOrString.String
+          "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"
+    , for = Some (Duration.show { amount = 60, unit = TimeUnit.Type.Minutes })
+    , labels = Some
+        (toMap { severity = AlertSeverity.show AlertSeverity.Type.Warning })
+    , annotations = Some
+        ( toMap
+            { summary = "High DNS Latency Rate Alert"
+            , description =
+                "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ \$value }}"
+            , runbook_url =
+                "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc"
+            }
+        )
+    }

--- a/config/observability/monitoring_resources/common/rules/HighDNSProviderErrorRate.dhall
+++ b/config/observability/monitoring_resources/common/rules/HighDNSProviderErrorRate.dhall
@@ -1,0 +1,33 @@
+let K8s =
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v6.0.0/package.dhall
+        sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
+
+let TimeUnit = ../../dhall/TimeUnit/package.dhall
+
+let Duration = ../../dhall/Duration/package.dhall
+
+let AlertSeverity = ../../dhall/AlertSeverity/package.dhall
+
+let PrometheusOperator =
+      ( https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v8.0.0/package.dhall
+          sha256:ebc5f0c5f57d410412c2b7cbb64d0883be648eafc094f0c3e10dba4e6bd46ed4
+      ).v1
+
+in  PrometheusOperator.Rule::{
+    , alert = Some "HighDNSProviderErrorRate"
+    , expr =
+        K8s.IntOrString.String
+          "sum(rate(glbc_aws_route53_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_aws_route53_request_total{}[5m])) by(pod) > 0.01"
+    , for = Some (Duration.show { amount = 60, unit = TimeUnit.Type.Minutes })
+    , labels = Some
+        (toMap { severity = AlertSeverity.show AlertSeverity.Type.Warning })
+    , annotations = Some
+        ( toMap
+            { summary = "High DNS Provider Error Rate"
+            , description =
+                "Excessive errors - The error rate is {{ \$value }}, which is greater than the threshold which is 1%"
+            , runbook_url =
+                "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSProviderErrorRate.adoc"
+            }
+        )
+    }

--- a/config/observability/monitoring_resources/common/rules/__glbc__.dhall
+++ b/config/observability/monitoring_resources/common/rules/__glbc__.dhall
@@ -1,1 +1,6 @@
-let rules = [ ./GLBCTargetDown.dhall ] in rules
+let rules =
+      [ ./GLBCTargetDown.dhall
+      , ./HighDNSProviderErrorRate.dhall
+      ]
+
+in  rules

--- a/config/observability/monitoring_resources/common/rules/__glbc__.dhall
+++ b/config/observability/monitoring_resources/common/rules/__glbc__.dhall
@@ -1,5 +1,6 @@
 let rules =
       [ ./GLBCTargetDown.dhall
+      , ./HighDNSLatencyAlert.dhall
       , ./HighDNSProviderErrorRate.dhall
       ]
 

--- a/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -35,3 +35,12 @@ spec:
           for: "5m"
           labels:
             severity: critical
+        - alert: HighDNSProviderErrorRate
+          annotations:
+            description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSProviderErrorRate.adoc
+            summary: High DNS Provider Error Rate
+          expr: "sum(rate(glbc_aws_route53_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_aws_route53_request_total{}[5m])) by(pod) > 0.01"
+          for: "60m"
+          labels:
+            severity: warning

--- a/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -37,7 +37,7 @@ spec:
             severity: critical
         - alert: HighDNSLatencyAlert
           annotations:
-            description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+            description: "High latency rate when requesting DNS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
             runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
             summary: High DNS Latency Rate Alert
           expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"

--- a/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -35,6 +35,15 @@ spec:
           for: "5m"
           labels:
             severity: critical
+        - alert: HighDNSLatencyAlert
+          annotations:
+            description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
+            summary: High DNS Latency Rate Alert
+          expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"
+          for: "60m"
+          labels:
+            severity: warning
         - alert: HighDNSProviderErrorRate
           annotations:
             description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -28,3 +28,12 @@ groups:
         for: "5m"
         labels:
           severity: critical
+      - alert: HighDNSProviderErrorRate
+        annotations:
+          description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSProviderErrorRate.adoc
+          summary: High DNS Provider Error Rate
+        expr: "sum(rate(glbc_aws_route53_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_aws_route53_request_total{}[5m])) by(pod) > 0.01"
+        for: "60m"
+        labels:
+          severity: warning

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -30,7 +30,7 @@ groups:
           severity: critical
       - alert: HighDNSLatencyAlert
         annotations:
-          description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+          description: "High latency rate when requesting DNS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5 seconds per request."
           runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
           summary: High DNS Latency Rate Alert
         expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -30,7 +30,7 @@ groups:
           severity: critical
       - alert: HighDNSLatencyAlert
         annotations:
-          description: "High latency rate when requesting DNS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5 seconds per request."
+          description: "High latency rate when requesting DNS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
           runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
           summary: High DNS Latency Rate Alert
         expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -28,6 +28,15 @@ groups:
         for: "5m"
         labels:
           severity: critical
+      - alert: HighDNSLatencyAlert
+        annotations:
+          description: "Less than 95% (0.95) of the requests are being served within 5 seconds. In the 95th percentile latency is {{ $value }}"
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighDNSLatencyAlert.adoc
+          summary: High DNS Latency Rate Alert
+        expr: "sum(rate(glbc_aws_route53_request_duration_seconds_sum[5m])) / sum(rate(glbc_aws_route53_request_duration_seconds_count[5m])) > 0.5"
+        for: "60m"
+        labels:
+          severity: warning
       - alert: HighDNSProviderErrorRate
         annotations:
           description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"

--- a/docs/observability/runbooks/HighDNSLatencyAlert.adoc
+++ b/docs/observability/runbooks/HighDNSLatencyAlert.adoc
@@ -1,0 +1,37 @@
+// begin header
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:numbered:
+:toc: macro
+:toc-title: pass:[<b>Table of Contents</b>]
+// end header
+= HighDNSLatencyAlert
+
+toc::[]
+
+== Description
+
+The source of the alert is the `someAlertMetric` metric. It fires when the condition foo is true.
+
+Add other helpful information about the alert here if necessary.
+
+== Prerequisites
+
+* Add any information that is needed or access to any system that is needed.
+
+== Execute/Resolution
+
+. Steps to troubleshoot & resolve
+
+== Validate
+
+What steps are required to verify that the procedure has been followed correctly and the required changes have been implemented correctly, with the desired outcome.
+
+. Check the alert is no longer firing.
+// Add any extra steps
+. Add more as necessary

--- a/docs/observability/runbooks/HighDNSLatencyAlert.adoc
+++ b/docs/observability/runbooks/HighDNSLatencyAlert.adoc
@@ -16,22 +16,28 @@ toc::[]
 
 == Description
 
-The source of the alert is the `someAlertMetric` metric. It fires when the condition foo is true.
-
-Add other helpful information about the alert here if necessary.
+The source of the alert is the `glbc_route_53_*` metric. It fires when there is high latency rate on the requests made.
+The alert will be triggered if requests are taking longer than 0.5 seconds. This usually means, the DNS provider is not responding, metrics is misconfigured, or the metrics endpoint is not responding.
 
 == Prerequisites
 
-* Add any information that is needed or access to any system that is needed.
+* Access to the physical cluster where GLBC should be running
 
 == Execute/Resolution
 
-. Steps to troubleshoot & resolve
+. Check the DNS & namespace for indications of problems.
++
+[source,sh]
+----
+kubectl logs deployment/kcp-glbc-controller-manager
+kubectl get events
+----
+If found a _5xx_ type error, proceed to verify the https://health.aws.amazon.com/health/status[AWS Health Status] for any know outages or issues.
+
+. Check the configuration (aws key & secret) to ensure they are correct.
+
+. Verify the https://health.aws.amazon.com/health/status[AWS Health Status]
 
 == Validate
 
-What steps are required to verify that the procedure has been followed correctly and the required changes have been implemented correctly, with the desired outcome.
-
 . Check the alert is no longer firing.
-// Add any extra steps
-. Add more as necessary

--- a/docs/observability/runbooks/HighDNSProviderErrorRate.adoc
+++ b/docs/observability/runbooks/HighDNSProviderErrorRate.adoc
@@ -1,0 +1,46 @@
+// begin header
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:numbered:
+:toc: macro
+:toc-title: pass:[<b>Table of Contents</b>]
+// end header
+= HighDNSProviderErrorRate
+
+toc::[]
+
+== Description
+
+The source of the alert is the `glbc_aws_route_53_*` metric. It fires when the error rate of the total requests made
+ is greater than the threshold which is 1%. This usually means, the DNS provider is not responding, metrics is misconfigured, or the metrics endpoint is not responding.
+
+== Prerequisites
+
+// Include the following steps in every alert SOP
+* Access to the physical cluster where GLBC should be running
+
+== Execute/Resolution
+
+// Include this as the first step in every alert SOP
+. Check the DNS & namespace for indications of problems.
++
+[source,sh]
+----
+kubectl logs deployment/kcp-glbc-controller-manager
+kubectl get events
+----
+If found a _5xx_ type error, proceed to verify the https://health.aws.amazon.com/health/status[AWS Health Status] for any know outages or issues.
+
+. Check the configuration (aws key & secret) to ensure they are correct.
+
+. Verify the https://health.aws.amazon.com/health/status[AWS Health Status]
+
+== Validate
+
+. Check the alert is no longer firing.
+// Add any extra steps


### PR DESCRIPTION
Closes #189 


## Description
I created two alerts:

- Triggered when calls to the DNS Provider (AWS Route 53) have excessive errors or disconnections:
  - The expression used for this divides the total errors by the total requests, giving us the error rate in percentage. At the moment, it is triggered when the error rate is higher than 1%.
  - I created the appropriate unit tests to verify that it is working. In the test, there is an error rate of 2% which will be expected for the alert to be triggered.

- Triggered when calls to the DNS Provider (AWS Route 53) have high latency.
  - The expression used for this divides the duration time in seconds by the total counted requests, giving us the latency rate. At the moment, it is triggered when the latency per request is greater than 0.5 seconds.
  - I created the unit test, there is a 0.6 seconds latency of which will be expected for the alert to be triggered.


I added documentation to each alert for SRE in case the alert is firing. This document provides more information on the alert and the prerequisites to solve the issue. Also, ideas on how it can be solved and how to troubleshoot it are also included.
