### PR TITLE
Add SLO multi-window multi-burn rate alerts

### DIFF
--- a/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -53,3 +53,113 @@ spec:
           for: "60m"
           labels:
             severity: warning
+    - name: SLOIngressAdmissionLatency
+      rules:
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 2.0% of the SLO error budget has been consumed over the past 5m and 1h windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate5m{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate1h{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+            )
+          labels:
+            severity: critical
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-30m6h
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 5.0% of the SLO error budget has been consumed over the past 30m and 6h windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate30m{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+            )
+          labels:
+            severity: critical
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-2h1d
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 10.0% of the SLO error budget has been consumed over the past 2h and 1d windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate2h{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate1d{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+            )
+          labels:
+            severity: warning
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-6h3d
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 10.0% of the SLO error budget has been consumed over the past 6h and 3d windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate3d{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+            )
+          labels:
+            severity: warning
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[5m]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[5m]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate5m
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[30m]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[30m]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate30m
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[2h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[2h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate2h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate1h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1d]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1d]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate1d
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[3d]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[3d]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate3d

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
@@ -46,3 +46,113 @@ groups:
         for: "60m"
         labels:
           severity: warning
+  - name: SLOIngressAdmissionLatency
+    rules:
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 2.0% of the SLO error budget has been consumed over the past 5m and 1h windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate5m{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate1h{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+          )
+        labels:
+          severity: critical
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-30m6h
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 5.0% of the SLO error budget has been consumed over the past 30m and 6h windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate30m{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+          )
+        labels:
+          severity: critical
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-2h1d
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 10.0% of the SLO error budget has been consumed over the past 2h and 1d windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate2h{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate1d{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+          )
+        labels:
+          severity: warning
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-6h3d
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 10.0% of the SLO error budget has been consumed over the past 6h and 3d windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate3d{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+          )
+        labels:
+          severity: warning
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[5m]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[5m]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate5m
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[30m]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[30m]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate30m
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[2h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[2h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate2h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate1h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1d]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1d]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate1d
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[3d]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[3d]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate3d

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/SLOIngressAdmissionLatency_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/SLOIngressAdmissionLatency_test.yaml
@@ -1,0 +1,230 @@
+rule_files:
+  - ../rules-glbc.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: glbc_ingress_managed_object_time_to_admission_bucket{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager",le="120"}
+        values: "0+60x60 3655+55x59 6960+60x5"
+      - series: glbc_ingress_managed_object_time_to_admission_count{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}
+        values: "0+60x60 3660+60x59 7260+60x5"
+    promql_expr_test:
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate5m
+        eval_time: 1h # 1x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate5m{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate5m
+        eval_time: 2h # 2x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate5m{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate5m
+        eval_time: 2h6m # 2x long window + 1x short window (+1m)
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate5m{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate1h
+        eval_time: 1h
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate1h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate1h
+        eval_time: 2h
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate1h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate1h
+        eval_time: 2h6m
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate1h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.07499999999999996
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h
+        exp_alerts: []
+      - eval_time: 2h
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              container: manager
+              job: observability-operator/podmonitor-kcp-glbc-controller-manager
+              namespace: test
+            exp_annotations:
+              summary: 'At least 2.0% of the SLO error budget has been consumed over the past 5m and 1h windows'
+              description: 'High error budget burn in namespace test (current value: 0.08333333333333337). Check the runbook for how to resolve this.'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc'
+      - eval_time: 2h6m
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h
+        exp_alerts: []
+  - interval: 1m
+    input_series:
+      - series: glbc_ingress_managed_object_time_to_admission_bucket{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager",le="120"}
+        values: "0+60x360 21655+55x359 41460+60x30"
+      - series: glbc_ingress_managed_object_time_to_admission_count{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}
+        values: "0+60x360 21660+60x359 43260+60x30"
+    promql_expr_test:
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate30m
+        eval_time: 6h # 1x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate30m{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate30m
+        eval_time: 12h # 2x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate30m{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate30m
+        eval_time: 12h31m # 2x long window + 1x short window (+1m)
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate30m{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        eval_time: 6h
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate6h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        eval_time: 12h
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate6h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        eval_time: 12h31m
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate6h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.0761574074074074
+    alert_rule_test:
+      - eval_time: 6h
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-30m6h
+        exp_alerts: []
+      - eval_time: 12h
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-30m6h
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              container: manager
+              job: observability-operator/podmonitor-kcp-glbc-controller-manager
+              namespace: test
+            exp_annotations:
+              summary: 'At least 5.0% of the SLO error budget has been consumed over the past 30m and 6h windows'
+              description: 'High error budget burn in namespace test (current value: 0.08333333333333337). Check the runbook for how to resolve this.'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc'
+      - eval_time: 12h31m
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-30m6h
+        exp_alerts: []
+  - interval: 1m
+    input_series:
+      - series: glbc_ingress_managed_object_time_to_admission_bucket{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager",le="120"}
+        values: "0+60x1440 86455+55x1439 165660+60x120"
+      - series: glbc_ingress_managed_object_time_to_admission_count{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}
+        values: "0+60x1440 86460+60x1439 172860+60x120"
+    promql_expr_test:
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate2h
+        eval_time: 1d # 1x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate2h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate2h
+        eval_time: 2d # 2x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate2h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate2h
+        eval_time: 2d2h1m # 2x long window + 1x short window (+1m)
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate2h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate1d
+        eval_time: 1d
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate1d{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate1d
+        eval_time: 2d
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate1d{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate1d
+        eval_time: 2d2h1m
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate1d{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.07633101851851853
+    alert_rule_test:
+      - eval_time: 1d
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-2h1d
+        exp_alerts: []
+      - eval_time: 2d
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-2h1d
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              container: manager
+              job: observability-operator/podmonitor-kcp-glbc-controller-manager
+              namespace: test
+            exp_annotations:
+              summary: 'At least 10.0% of the SLO error budget has been consumed over the past 2h and 1d windows'
+              description: 'High error budget burn in namespace test (current value: 0.08333333333333337). Check the runbook for how to resolve this.'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc'
+      - eval_time: 2d2h1m
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-2h1d
+        exp_alerts: []
+  - interval: 1m
+    input_series:
+      - series: glbc_ingress_managed_object_time_to_admission_bucket{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager",le="120"}
+        values: "0+60x4320 259255+55x4319 496860+60x360"
+      - series: glbc_ingress_managed_object_time_to_admission_count{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}
+        values: "0+60x4320 259260+60x4319 518460+60x360"
+    promql_expr_test:
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        eval_time: 3d # 1x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate6h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        eval_time: 6d # 2x long window
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate6h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        eval_time: 6d6h1m # 2x long window + 1x short window (+1m)
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate6h{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate3d
+        eval_time: 3d
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate3d{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate3d
+        eval_time: 6d
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate3d{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.08333333333333337
+      - expr: glbc_ingress_managed_object_time_to_admission:burnrate3d
+        eval_time: 6d6h1m
+        exp_samples:
+          - labels: 'glbc_ingress_managed_object_time_to_admission:burnrate3d{namespace="test",container="manager",job="observability-operator/podmonitor-kcp-glbc-controller-manager"}'
+            value: 0.07636959876543215
+    alert_rule_test:
+      - eval_time: 3d
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-6h3d
+        exp_alerts: []
+      - eval_time: 6d
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-6h3d
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              container: manager
+              job: observability-operator/podmonitor-kcp-glbc-controller-manager
+              namespace: test
+            exp_annotations:
+              summary: 'At least 10.0% of the SLO error budget has been consumed over the past 6h and 3d windows'
+              description: 'High error budget burn in namespace test (current value: 0.08333333333333337). Check the runbook for how to resolve this.'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc'
+      - eval_time: 6d6h1m
+        alertname: SLOIngressAdmissionLatency-ErrorBudgetBurn-6h3d
+        exp_alerts: []

--- a/config/observability/monitoring_resources/common/rules-glbc.dhall
+++ b/config/observability/monitoring_resources/common/rules-glbc.dhall
@@ -13,5 +13,6 @@ in  PrometheusOperator.PrometheusRuleSpec::{
         , name = "glbc"
         , rules = Some ./rules/__glbc__.dhall
         }
+      , ./rules/SLOIngressAdmissionLatency.dhall
       ]
     }

--- a/config/observability/monitoring_resources/common/rules/SLOIngressAdmissionLatency.dhall
+++ b/config/observability/monitoring_resources/common/rules/SLOIngressAdmissionLatency.dhall
@@ -1,0 +1,159 @@
+let Prelude =
+      https://prelude.dhall-lang.org/v21.1.0/package.dhall
+        sha256:0fed19a88330e9a8a3fbe1e8442aa11d12e38da51eb12ba8bcb56f3c25d0854a
+
+let K8s =
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v6.0.0/package.dhall
+        sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
+
+let TimeUnit = ../../dhall/TimeUnit/package.dhall
+
+let Duration = ../../dhall/Duration/package.dhall
+
+let AlertSeverity = ../../dhall/AlertSeverity/package.dhall
+
+let AlertProperties = ../../dhall/AlertProperties/package.dhall
+
+let PrometheusOperator =
+      ( https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v8.0.0/package.dhall
+          sha256:ebc5f0c5f57d410412c2b7cbb64d0883be648eafc094f0c3e10dba4e6bd46ed4
+      ).v1
+
+let metric = "glbc_ingress_managed_object_time_to_admission"
+
+let alertName = "SLOIngressAdmissionLatency"
+
+let metricLabels =
+      "container=\"manager\",job=~\".*kcp-glbc-controller-manager\""
+
+let sloTarget = 0.999
+
+let sloLatencyLabel = "le=\"120\""
+
+let runbookUrl =
+      "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/${alertName}.adoc"
+
+let alertProperties =
+      [ AlertProperties::{
+        , burnRate = 13.44
+        , shortDuration = { amount = 5, unit = TimeUnit.Type.Minutes }
+        , longDuration = { amount = 1, unit = TimeUnit.Type.Hours }
+        , percentBurn = 2.0
+        , severity = AlertSeverity.Type.Critical
+        }
+      , AlertProperties::{
+        , burnRate = 5.6
+        , shortDuration = { amount = 30, unit = TimeUnit.Type.Minutes }
+        , longDuration = { amount = 6, unit = TimeUnit.Type.Hours }
+        , percentBurn = 5.0
+        , severity = AlertSeverity.Type.Critical
+        }
+      , AlertProperties::{
+        , burnRate = 2.8
+        , shortDuration = { amount = 2, unit = TimeUnit.Type.Hours }
+        , longDuration = { amount = 1, unit = TimeUnit.Type.Days }
+        , percentBurn = 10.0
+        , severity = AlertSeverity.Type.Warning
+        }
+      , AlertProperties::{
+        , burnRate = 0.933
+        , shortDuration = { amount = 6, unit = TimeUnit.Type.Hours }
+        , longDuration = { amount = 3, unit = TimeUnit.Type.Days }
+        , percentBurn = 10.0
+        , severity = AlertSeverity.Type.Warning
+        }
+      ]
+
+let labelsFrom =
+      λ(ap : AlertProperties.Type) →
+        Some (toMap { severity = AlertSeverity.show ap.severity })
+
+let alertRuleExprFrom =
+      λ(ap : AlertProperties.Type) →
+        ''
+        (
+          ${metric}:burnrate${Duration.show
+                                ap.shortDuration}{${metricLabels}} > (${Double/show
+                                                                          ap.burnRate} * (1-${Double/show
+                                                                                                sloTarget}))
+          and
+          ${metric}:burnrate${Duration.show
+                                ap.longDuration}{${metricLabels}} > (${Double/show
+                                                                         ap.burnRate} * (1-${Double/show
+                                                                                               sloTarget}))
+        )
+        ''
+
+let makeAlertRules =
+      λ(aps : List AlertProperties.Type) →
+        Prelude.List.map
+          AlertProperties.Type
+          PrometheusOperator.Rule.Type
+          ( λ(ap : AlertProperties.Type) →
+              PrometheusOperator.Rule::{
+              , alert = Some
+                  (     "${alertName}-ErrorBudgetBurn-"
+                    ++  Duration.show ap.shortDuration
+                    ++  Duration.show ap.longDuration
+                  )
+              , expr = K8s.IntOrString.String (alertRuleExprFrom ap)
+              , labels = labelsFrom ap
+              , annotations = Some
+                  ( toMap
+                      { runbook_url = runbookUrl
+                      , summary =
+                          "At least ${Double/show
+                                        ap.percentBurn}% of the SLO error budget has been consumed over the past ${Duration.show
+                                                                                                                     ap.shortDuration} and ${Duration.show
+                                                                                                                                               ap.longDuration} windows"
+                      , description =
+                          "High error budget burn in namespace {{ \$labels.namespace }} (current value: {{ \$value }}). Check the runbook for how to resolve this."
+                      }
+                  )
+              }
+          )
+          aps
+
+let recordingRuleExprFrom =
+      λ(duration : Duration.Type) →
+        ''
+        1 - (
+          sum by(container,job,namespace) (rate(${metric}_bucket{${metricLabels},${sloLatencyLabel}}[${Duration.show
+                                                                                                         duration}]))
+          /
+          sum by(container,job,namespace) (rate(${metric}_count{${metricLabels}}[${Duration.show
+                                                                                     duration}]))
+        )
+        ''
+
+let makeRecordingRule =
+      λ(duration : Duration.Type) →
+        PrometheusOperator.Rule::{
+        , expr = K8s.IntOrString.String (recordingRuleExprFrom duration)
+        , record = Some "${metric}:burnrate${Duration.show duration}"
+        }
+
+let makeShortDurationRecordingRules =
+      λ(aps : List AlertProperties.Type) →
+        Prelude.List.map
+          AlertProperties.Type
+          PrometheusOperator.Rule.Type
+          (λ(ap : AlertProperties.Type) → makeRecordingRule ap.shortDuration)
+          aps
+
+let makeLongDurationRecordingRules =
+      λ(aps : List AlertProperties.Type) →
+        Prelude.List.map
+          AlertProperties.Type
+          PrometheusOperator.Rule.Type
+          (λ(ap : AlertProperties.Type) → makeRecordingRule ap.longDuration)
+          aps
+
+in  PrometheusOperator.RuleGroup::{
+    , name = "${alertName}"
+    , rules = Some
+        (   makeAlertRules alertProperties
+          # makeShortDurationRecordingRules alertProperties
+          # makeLongDurationRecordingRules alertProperties
+        )
+    }

--- a/config/observability/monitoring_resources/dhall/AlertProperties/Type.dhall
+++ b/config/observability/monitoring_resources/dhall/AlertProperties/Type.dhall
@@ -8,7 +8,6 @@ let AlertProperties
         burnRate : Double
       , longDuration : Duration.Type
       , shortDuration : Duration.Type
-      , for : Duration.Type
       , severity : AlertSeverity.Type
       , percentBurn : Double
       }

--- a/config/observability/observability.mk
+++ b/config/observability/observability.mk
@@ -119,7 +119,7 @@ gen-alert-rule-runbook:
 	@echo
 
 .PHONY: gen-rules-list
-gen-rules-list: RULES_FILES="$(shell echo $(addprefix "./", $(shell ls $(DHALL_RULES_SOURCE_DIR)|grep -v -E '__.*__.dhall|DeadMansSwitch.dhall')) | sed 's/ /, /g')"
+gen-rules-list: RULES_FILES="$(shell echo $(addprefix "./", $(shell ls $(DHALL_RULES_SOURCE_DIR)|grep -v -E '__.*__.dhall|DeadMansSwitch.dhall|SLOIngressAdmissionLatency.dhall')) | sed 's/ /, /g')"
 gen-rules-list:
 	@echo "let rules = [ $(RULES_FILES) ] in rules" > $(DHALL_RULES_SOURCE_DIR)/__glbc__.dhall
 

--- a/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -53,3 +53,113 @@ spec:
           for: "60m"
           labels:
             severity: warning
+    - name: SLOIngressAdmissionLatency
+      rules:
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 2.0% of the SLO error budget has been consumed over the past 5m and 1h windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate5m{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate1h{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+            )
+          labels:
+            severity: critical
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-30m6h
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 5.0% of the SLO error budget has been consumed over the past 30m and 6h windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate30m{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+            )
+          labels:
+            severity: critical
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-2h1d
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 10.0% of the SLO error budget has been consumed over the past 2h and 1d windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate2h{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate1d{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+            )
+          labels:
+            severity: warning
+        - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-6h3d
+          annotations:
+            description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+            summary: "At least 10.0% of the SLO error budget has been consumed over the past 6h and 3d windows"
+          expr: |
+            (
+              glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+              and
+              glbc_ingress_managed_object_time_to_admission:burnrate3d{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+            )
+          labels:
+            severity: warning
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[5m]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[5m]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate5m
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[30m]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[30m]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate30m
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[2h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[2h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate2h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate1h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1d]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1d]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate1d
+        - expr: |
+            1 - (
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[3d]))
+              /
+              sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[3d]))
+            )
+          record: glbc_ingress_managed_object_time_to_admission:burnrate3d

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -46,3 +46,113 @@ groups:
         for: "60m"
         labels:
           severity: warning
+  - name: SLOIngressAdmissionLatency
+    rules:
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 2.0% of the SLO error budget has been consumed over the past 5m and 1h windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate5m{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate1h{container="manager",job=~".*kcp-glbc-controller-manager"} > (13.44 * (1-0.999))
+          )
+        labels:
+          severity: critical
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-30m6h
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 5.0% of the SLO error budget has been consumed over the past 30m and 6h windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate30m{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (5.6 * (1-0.999))
+          )
+        labels:
+          severity: critical
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-2h1d
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 10.0% of the SLO error budget has been consumed over the past 2h and 1d windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate2h{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate1d{container="manager",job=~".*kcp-glbc-controller-manager"} > (2.8 * (1-0.999))
+          )
+        labels:
+          severity: warning
+      - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-6h3d
+        annotations:
+          description: "High error budget burn in namespace {{ $labels.namespace }} (current value: {{ $value }}). Check the runbook for how to resolve this."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+          summary: "At least 10.0% of the SLO error budget has been consumed over the past 6h and 3d windows"
+        expr: |
+          (
+            glbc_ingress_managed_object_time_to_admission:burnrate6h{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+            and
+            glbc_ingress_managed_object_time_to_admission:burnrate3d{container="manager",job=~".*kcp-glbc-controller-manager"} > (0.933 * (1-0.999))
+          )
+        labels:
+          severity: warning
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[5m]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[5m]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate5m
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[30m]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[30m]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate30m
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[2h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[2h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate2h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate1h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[6h]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[6h]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate6h
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[1d]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[1d]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate1d
+      - expr: |
+          1 - (
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_bucket{container="manager",job=~".*kcp-glbc-controller-manager",le="120"}[3d]))
+            /
+            sum by(container,job,namespace) (rate(glbc_ingress_managed_object_time_to_admission_count{container="manager",job=~".*kcp-glbc-controller-manager"}[3d]))
+          )
+        record: glbc_ingress_managed_object_time_to_admission:burnrate3d

--- a/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
+++ b/docs/observability/runbooks/SLOIngressAdmissionLatency.adoc
@@ -1,0 +1,55 @@
+// begin header
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:numbered:
+:toc: macro
+:toc-title: pass:[<b>Table of Contents</b>]
+// end header
+= SLOIngressAdmissionLatency
+
+toc::[]
+
+== Description
+
+The various SLOIngressAdmissionLatency ErrorBudgetBurn alerts follow the best practice for alerting on SLOs as described in the https://sre.google/workbook/alerting-on-slos/[SRE Workbook]. The format of the alert name includes the short & long alert windows e.g. 5m1h for a 5 minute short window & 1 hour long window. If one of these alerts is firing, it is a signal that the error budget is being burned at a rate that will see it exhausted soon. The severity of the alert is `critical`` for burn rates that would need immediate action. For a lower, but sustained rate of burn (e.g. exhausation in 3 days), a `warning` severity is used. Due to the long time ranges used for data in these alerts, and the different terms (burn rate, windows, error budget) it can be confusing at first as to why an alert is firing, or continuing to fire after a problem has been resolved. In general, the longer the window used for an alert, the longer it will take for an alert to have sufficient 'good' data before it stops firing again. The SRE Workbook explains this best.
+
+The metric used for these alerts is the histogram `glbc_ingress_managed_object_time_to_admission`.
+The `glbc_ingress_managed_object_time_to_admission_bucket` metric has an `le` (less than or equal) label for different time buckets, in seconds. They catch Ingress admission times from start to finish. That is, from when the GLBC first saw the Ingress all the way through to the DNS host being set up and TLS certificate secret being created in the target workload cluster. The `glbc_ingress_managed_object_time_to_admission_count` metric holds a count on the total number of admissions. A burn rate calculation uses these 2 metrics e.g. :
+
+[source]
+----
+          1 - (
+              rate(glbc_ingress_managed_object_time_to_admission_bucket{le="120"}[5m]))
+              /
+              rate(glbc_ingress_managed_object_time_to_admission_count[5m]))
+          )
+----
+
+So if the rate of admissions over the last 5 minutes was 20 per second, and the rate of admissions that took less than 2 minutes (120 seconds) was 15 per second, the burn rate is 1 - (15 / 20), or 1 - 0.75 = 0.25 .
+
+These alerts cover a lot of moving parts. This is deliberate to capture what users will care about most i.e. their ingress gets set up correctly and they can send traffic to their service.
+This can make initial troubleshooting slow. However, there are usually other 'cause based' alerts firing at the same time that should help narrow down the problem.
+
+== Prerequisites
+
+* Access to the physical cluster where GLBC should be running
+
+== Execute/Resolution
+
+First check if there are any other firing alerts. The SLO Alerts are 'symptom based alerts', which means they are indicating there is a problem from the users point of view. The actual cause may not be obvious without doing additional troubleshooting.
+The SLO covers a number of different moving parts, such as creating a DNS record, requesting a TLS certificate to be signed and various API calls to the control plane (KCP). The cause could be with any of controllers in glbc, the configuratino for them, or the service they depend on (like Route 53 or Lets Encrypt). 
+
+If other firing alerts are not giving sufficient information or there are no other firing alerts, the next most useful thing is to review recent logs. There may be errors that are currently not captured in an alerting rule. Review any errors or warning logs first for signs of misbehaviour, communication issues or misconfiguration. Failing that, it may be useful to check lesser level logs and any kubernetes events for hints on what may be going wrong.
+
+It can also be helpful to narrow time a time frame for when the problem started to happen. The GLBC Overview dashboard in Grafana can help with that by showing any error spikes, high load, or graphs that no longer follow a pattern (fall off a cliff or rise sharply). Absence of data or gaps in a graph can also indicate a problem.
+
+== Validate
+
+Note that any change that attempts to fix the problem may stop a 'cause based' alert firing, but the SLO 'symptom based alert' could continue firing for some time. The actual time depends on how fast the error budget had been burning, and the short window time for the firing alert(s). It is better to look for a downward tendency in a graph of the alert metric as an indicator the issue may be resolved. The easiest way to see such a graph is to click on the alert expression in the Prometheus Alerts tab, which will then open it in the Graph tab.
+
+After the short window has elapsed some time later, you can verify the SLO alert has stopped firing.


### PR DESCRIPTION
Closes #186 

## Description of Changes

* Adds 4 new alert rules (2x critical, 2x warning) for the initial Service Level Objective (SLO). 
* Adds unit tests for the alerts to cover short & long windows, and reset
* Adds a runbook for when one of these alerts fire <-- **START HERE FOR MORE CONTEXT ON SLO ALERTING** 

Although the practiced SLO in the early days of running this as a service will be lower than 99.9%, the alerts are set up as if it was 99.9%.
This is for 2 reasons:
* it provides a good indicator of how well we're doing on the objective against how we *want* to be before we're happy to offer it to users
* there is additional complexity in calculating the alert queries when the SLO is lower than 99.9% such that they are still useful. For example, if we used the recommended numbers in the [SRE Workbook](https://sre.google/workbook/alerting-on-slos/) with a lower SLO of 50%, some of the alerts cannot possibly fire (It's not possible to use 2% of your budget in 1 hour)

I intend to follow up on this PR with some new visuals in Grafana for how the SLO is performing & how much error budget remains.

