### PR TITLE
Tls certificate alerts

### DIFF
--- a/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -53,6 +53,24 @@ spec:
           for: "60m"
           labels:
             severity: warning
+        - alert: HighTLSProviderErrorRate
+          annotations:
+            description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+            summary: High TLS Provider Error Rate
+          expr: "sum(rate(glbc_tls_certificate_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_tls_certificate_request_total{}[5m])) by(pod) > 0.01"
+          for: "60m"
+          labels:
+            severity: warning
+        - alert: HighTLSProviderLatencyAlert
+          annotations:
+            description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+            summary: High TLS Latency Rate Alert
+          expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+          for: "60m"
+          labels:
+            severity: warning
     - name: SLOIngressAdmissionLatency
       rules:
         - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -64,10 +64,10 @@ spec:
             severity: warning
         - alert: HighTLSProviderLatencyAlert
           annotations:
-            description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+            description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 120 seconds."
             runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
             summary: High TLS Latency Rate Alert
-          expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+          expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 120"
           for: "60m"
           labels:
             severity: warning

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
@@ -57,10 +57,10 @@ groups:
           severity: warning
       - alert: HighTLSProviderLatencyAlert
         annotations:
-          description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+          description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 120 seconds."
           runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
           summary: High TLS Latency Rate Alert
-        expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+        expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 120"
         for: "60m"
         labels:
           severity: warning

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
@@ -46,6 +46,24 @@ groups:
         for: "60m"
         labels:
           severity: warning
+      - alert: HighTLSProviderErrorRate
+        annotations:
+          description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+          summary: High TLS Provider Error Rate
+        expr: "sum(rate(glbc_tls_certificate_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_tls_certificate_request_total{}[5m])) by(pod) > 0.01"
+        for: "60m"
+        labels:
+          severity: warning
+      - alert: HighTLSProviderLatencyAlert
+        annotations:
+          description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+          summary: High TLS Latency Rate Alert
+        expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+        for: "60m"
+        labels:
+          severity: warning
   - name: SLOIngressAdmissionLatency
     rules:
       - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighTLSProviderErrorRate_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighTLSProviderErrorRate_test.yaml
@@ -1,0 +1,26 @@
+rule_files:
+  - ../rules-glbc.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: glbc_tls_certificate_request_errors_total{pod="glbc"}
+        values: "0+0x60 2+2x65"
+      - series: glbc_tls_certificate_request_total{pod="glbc"}
+        values: "100+100x125"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: HighTLSProviderErrorRate
+        exp_alerts: []
+      - eval_time: 125m
+        alertname: HighTLSProviderErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              pod: glbc
+            exp_annotations:
+              summary: 'High TLS Provider Error Rate'
+              description: 'Excessive errors - The error rate is 0.02, which is greater than the threshold which is 1%'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderErrorRate.adoc'

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighTLSProviderLatencyAlert_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighTLSProviderLatencyAlert_test.yaml
@@ -1,0 +1,25 @@
+rule_files:
+  - ../rules-glbc.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: glbc_tls_certificate_issuance_duration_seconds_sum{pod="glbc"}
+        values: "0+0x60 0+6x65"
+      - series: glbc_tls_certificate_issuance_duration_seconds_count{pod="glbc"}
+        values: "0+0x60 0+10x65"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: HighTLSProviderLatencyAlert
+        exp_alerts: []
+      - eval_time: 125m
+        alertname: HighTLSProviderLatencyAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: 'High TLS Latency Rate Alert'
+              description: 'High latency rate when requesting TLS - The latency rate is 0.6000000000000001 seconds, which is greater than our threshold which is 0.5seconds.'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc'

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighTLSProviderLatencyAlert_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/HighTLSProviderLatencyAlert_test.yaml
@@ -7,9 +7,9 @@ tests:
   - interval: 1m
     input_series:
       - series: glbc_tls_certificate_issuance_duration_seconds_sum{pod="glbc"}
-        values: "0+0x60 0+6x65"
+        values: "0+0x60 0+121x65"
       - series: glbc_tls_certificate_issuance_duration_seconds_count{pod="glbc"}
-        values: "0+0x60 0+10x65"
+        values: "0+0x60 0+1x65"
     alert_rule_test:
       - eval_time: 60m
         alertname: HighTLSProviderLatencyAlert
@@ -21,5 +21,5 @@ tests:
               severity: warning
             exp_annotations:
               summary: 'High TLS Latency Rate Alert'
-              description: 'High latency rate when requesting TLS - The latency rate is 0.6000000000000001 seconds, which is greater than our threshold which is 0.5seconds.'
+              description: 'High latency rate when requesting TLS - The latency rate is 121 seconds, which is greater than our threshold which is 120 seconds.'
               runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc'

--- a/config/observability/monitoring_resources/common/rules/HighTLSProviderErrorRate.dhall
+++ b/config/observability/monitoring_resources/common/rules/HighTLSProviderErrorRate.dhall
@@ -1,0 +1,33 @@
+let K8s =
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v6.0.0/package.dhall
+        sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
+
+let TimeUnit = ../../dhall/TimeUnit/package.dhall
+
+let Duration = ../../dhall/Duration/package.dhall
+
+let AlertSeverity = ../../dhall/AlertSeverity/package.dhall
+
+let PrometheusOperator =
+      ( https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v8.0.0/package.dhall
+          sha256:ebc5f0c5f57d410412c2b7cbb64d0883be648eafc094f0c3e10dba4e6bd46ed4
+      ).v1
+
+in  PrometheusOperator.Rule::{
+    , alert = Some "HighTLSProviderErrorRate"
+    , expr =
+        K8s.IntOrString.String
+          "sum(rate(glbc_tls_certificate_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_tls_certificate_request_total{}[5m])) by(pod) > 0.01"
+    , for = Some (Duration.show { amount = 60, unit = TimeUnit.Type.Minutes })
+    , labels = Some
+        (toMap { severity = AlertSeverity.show AlertSeverity.Type.Warning })
+    , annotations = Some
+        ( toMap
+            { summary = "High TLS Provider Error Rate"
+            , description =
+                "Excessive errors - The error rate is {{ \$value }}, which is greater than the threshold which is 1%"
+            , runbook_url =
+                "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderErrorRate.adoc"
+            }
+        )
+    }

--- a/config/observability/monitoring_resources/common/rules/HighTLSProviderLatencyAlert.dhall
+++ b/config/observability/monitoring_resources/common/rules/HighTLSProviderLatencyAlert.dhall
@@ -17,7 +17,7 @@ in  PrometheusOperator.Rule::{
     , alert = Some "HighTLSProviderLatencyAlert"
     , expr =
         K8s.IntOrString.String
-          "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+          "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 120"
     , for = Some (Duration.show { amount = 60, unit = TimeUnit.Type.Minutes })
     , labels = Some
         (toMap { severity = AlertSeverity.show AlertSeverity.Type.Warning })
@@ -25,7 +25,7 @@ in  PrometheusOperator.Rule::{
         ( toMap
             { summary = "High TLS Latency Rate Alert"
             , description =
-                "High latency rate when requesting TLS - The latency rate is {{ \$value }} seconds, which is greater than our threshold which is 0.5seconds."
+                "High latency rate when requesting TLS - The latency rate is {{ \$value }} seconds, which is greater than our threshold which is 120 seconds."
             , runbook_url =
                 "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc"
             }

--- a/config/observability/monitoring_resources/common/rules/HighTLSProviderLatencyAlert.dhall
+++ b/config/observability/monitoring_resources/common/rules/HighTLSProviderLatencyAlert.dhall
@@ -1,0 +1,33 @@
+let K8s =
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v6.0.0/package.dhall
+        sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
+
+let TimeUnit = ../../dhall/TimeUnit/package.dhall
+
+let Duration = ../../dhall/Duration/package.dhall
+
+let AlertSeverity = ../../dhall/AlertSeverity/package.dhall
+
+let PrometheusOperator =
+      ( https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v8.0.0/package.dhall
+          sha256:ebc5f0c5f57d410412c2b7cbb64d0883be648eafc094f0c3e10dba4e6bd46ed4
+      ).v1
+
+in  PrometheusOperator.Rule::{
+    , alert = Some "HighTLSProviderLatencyAlert"
+    , expr =
+        K8s.IntOrString.String
+          "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+    , for = Some (Duration.show { amount = 60, unit = TimeUnit.Type.Minutes })
+    , labels = Some
+        (toMap { severity = AlertSeverity.show AlertSeverity.Type.Warning })
+    , annotations = Some
+        ( toMap
+            { summary = "High TLS Latency Rate Alert"
+            , description =
+                "High latency rate when requesting TLS - The latency rate is {{ \$value }} seconds, which is greater than our threshold which is 0.5seconds."
+            , runbook_url =
+                "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc"
+            }
+        )
+    }

--- a/config/observability/monitoring_resources/common/rules/__glbc__.dhall
+++ b/config/observability/monitoring_resources/common/rules/__glbc__.dhall
@@ -2,6 +2,8 @@ let rules =
       [ ./GLBCTargetDown.dhall
       , ./HighDNSLatencyAlert.dhall
       , ./HighDNSProviderErrorRate.dhall
+      , ./HighTLSProviderErrorRate.dhall
+      , ./HighTLSProviderLatencyAlert.dhall
       ]
 
 in  rules

--- a/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -53,6 +53,24 @@ spec:
           for: "60m"
           labels:
             severity: warning
+        - alert: HighTLSProviderErrorRate
+          annotations:
+            description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+            summary: High TLS Provider Error Rate
+          expr: "sum(rate(glbc_tls_certificate_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_tls_certificate_request_total{}[5m])) by(pod) > 0.01"
+          for: "60m"
+          labels:
+            severity: warning
+        - alert: HighTLSProviderLatencyAlert
+          annotations:
+            description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+            summary: High TLS Latency Rate Alert
+          expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+          for: "60m"
+          labels:
+            severity: warning
     - name: SLOIngressAdmissionLatency
       rules:
         - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h

--- a/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -64,10 +64,10 @@ spec:
             severity: warning
         - alert: HighTLSProviderLatencyAlert
           annotations:
-            description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+            description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 120 seconds."
             runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
             summary: High TLS Latency Rate Alert
-          expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+          expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 120"
           for: "60m"
           labels:
             severity: warning

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -57,10 +57,10 @@ groups:
           severity: warning
       - alert: HighTLSProviderLatencyAlert
         annotations:
-          description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+          description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 120 seconds."
           runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
           summary: High TLS Latency Rate Alert
-        expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+        expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 120"
         for: "60m"
         labels:
           severity: warning

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -46,6 +46,24 @@ groups:
         for: "60m"
         labels:
           severity: warning
+      - alert: HighTLSProviderErrorRate
+        annotations:
+          description: "Excessive errors - The error rate is {{ $value }}, which is greater than the threshold which is 1%"
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+          summary: High TLS Provider Error Rate
+        expr: "sum(rate(glbc_tls_certificate_request_errors_total{}[5m])) by(pod) / sum(rate(glbc_tls_certificate_request_total{}[5m])) by(pod) > 0.01"
+        for: "60m"
+        labels:
+          severity: warning
+      - alert: HighTLSProviderLatencyAlert
+        annotations:
+          description: "High latency rate when requesting TLS - The latency rate is {{ $value }} seconds, which is greater than our threshold which is 0.5seconds."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+          summary: High TLS Latency Rate Alert
+        expr: "sum(rate(glbc_tls_certificate_issuance_duration_seconds_sum[5m])) / sum(rate(glbc_tls_certificate_issuance_duration_seconds_count[5m])) > 0.5"
+        for: "60m"
+        labels:
+          severity: warning
   - name: SLOIngressAdmissionLatency
     rules:
       - alert: SLOIngressAdmissionLatency-ErrorBudgetBurn-5m1h

--- a/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+++ b/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
@@ -1,0 +1,48 @@
+// begin header
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:numbered:
+:toc: macro
+:toc-title: pass:[<b>Table of Contents</b>]
+// end header
+= HighTLSProviderErrorRate
+
+toc::[]
+
+== Description
+
+The source of the alert is the `glbc_tls_certificate_*` metric. It fires when the error rate of the total requests made
+is greater than the threshold which is 1%. This usually means, the TLS certificate provider is not responding, metrics is misconfigured, or the metrics endpoint is not responding.
+
+== Prerequisites
+
+// Include the following steps in every alert SOP
+* Access to the physical cluster where GLBC should be running
+
+== Execute/Resolution
+
+. Check the TLS cert provider & namespace for indications of problems.
++
+[source,sh]
+----
+kubectl logs deployment/kcp-glbc-controller-manager
+kubectl get events
+----
+. The following link shows how to https://cert-manager.io/docs/faq/troubleshooting/#troubleshooting-a-failed-certificate-request[Troubleshoot a Failed Certificate Request].
+You will find:
+    - How to check the Certificate resource.
+    - How to check the CertificateRequest
+    - How to check the issuer state.
+. https://cert-manager.io/docs/faq/acme/[Troubleshooting Issuing ACME Certificates] such as Let's Encrypt.
+
+
+
+== Validate
+
+. Check the alert is no longer firing.
+// Add any extra steps

--- a/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+++ b/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
@@ -30,8 +30,7 @@ is greater than the threshold which is 1%. This usually means, the TLS certifica
 +
 [source,sh]
 ----
-kubectl logs deployment/kcp-glbc-controller-manager
-kubectl get events
+kubectl get events -n kcp32653cc5662de9ab2054113507ac53e657ff4afc2a52926039fbc4cd
 ----
 . The following link shows how to https://cert-manager.io/docs/faq/troubleshooting/#troubleshooting-a-failed-certificate-request[Troubleshoot a Failed Certificate Request].
 You will find:
@@ -39,7 +38,7 @@ You will find:
     - How to check the CertificateRequest
     - How to check the issuer state.
 . https://cert-manager.io/docs/faq/acme/[Troubleshooting Issuing ACME Certificates] such as Let's Encrypt.
-
+. Let's Encrypt does not provide support via email. Support questions are answered in their https://community.letsencrypt.org/[community forums].
 
 
 == Validate

--- a/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+++ b/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
@@ -39,7 +39,7 @@ You will find:
     - How to check the issuer state.
 . https://cert-manager.io/docs/faq/acme/[Troubleshooting Issuing ACME Certificates] such as Let's Encrypt.
 . Let's Encrypt does not provide support via email. Support questions are answered in their https://community.letsencrypt.org/[community forums].
-
+. Check the status of https://letsencrypt.status.io/[Let's Encrypt]
 
 == Validate
 

--- a/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+++ b/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
@@ -1,0 +1,48 @@
+// begin header
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:numbered:
+:toc: macro
+:toc-title: pass:[<b>Table of Contents</b>]
+// end header
+= HighTLSProviderLatencyAlert
+
+toc::[]
+
+== Description
+
+The source of the alert is the `glbc_tls_certificate_*` metric. It fires when there is high latency rate on the requests made.
+The alert will be triggered if requests are taking longer than 0.5 seconds. This usually means, the TLS certificate provider is not responding, metrics is misconfigured, or the metrics endpoint is not responding.
+
+== Prerequisites
+
+// Include the following steps in every alert SOP
+* Access to the physical cluster where GLBC should be running
+
+== Execute/Resolution
+
+. Check the TLS cert provider & namespace for indications of problems.
++
+[source,sh]
+----
+kubectl logs deployment/kcp-glbc-controller-manager
+kubectl get events
+----
+. The following link shows how to https://cert-manager.io/docs/faq/troubleshooting/#troubleshooting-a-failed-certificate-request[Troubleshoot a Failed Certificate Request].
+You will find:
+- How to check the Certificate resource.
+- How to check the CertificateRequest
+- How to check the issuer state.
+. https://cert-manager.io/docs/faq/acme/[Troubleshooting Issuing ACME Certificates] such as Let's Encrypt.
+
+
+
+== Validate
+
+. Check the alert is no longer firing.
+// Add any extra steps

--- a/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+++ b/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
@@ -39,7 +39,7 @@ You will find:
 - How to check the issuer state.
 . https://cert-manager.io/docs/faq/acme/[Troubleshooting Issuing ACME Certificates] such as Let's Encrypt.
 . Let's Encrypt does not provide support via email. Support questions are answered in their https://community.letsencrypt.org/[community forums].
-
+. Check the status of https://letsencrypt.status.io/[Let's Encrypt]
 
 
 == Validate

--- a/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+++ b/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
@@ -17,7 +17,7 @@ toc::[]
 == Description
 
 The source of the alert is the `glbc_tls_certificate_*` metric. It fires when there is high latency rate on the requests made.
-The alert will be triggered if requests are taking longer than 0.5 seconds. This usually means, the TLS certificate provider is not responding, metrics is misconfigured, or the metrics endpoint is not responding.
+The alert will be triggered if requests are taking longer than 120 seconds. This usually means, the TLS certificate provider is not responding, metrics is misconfigured, or the metrics endpoint is not responding.
 
 == Prerequisites
 

--- a/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+++ b/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
@@ -30,8 +30,7 @@ The alert will be triggered if requests are taking longer than 0.5 seconds. This
 +
 [source,sh]
 ----
-kubectl logs deployment/kcp-glbc-controller-manager
-kubectl get events
+kubectl get events -n kcp32653cc5662de9ab2054113507ac53e657ff4afc2a52926039fbc4cd
 ----
 . The following link shows how to https://cert-manager.io/docs/faq/troubleshooting/#troubleshooting-a-failed-certificate-request[Troubleshoot a Failed Certificate Request].
 You will find:
@@ -39,6 +38,7 @@ You will find:
 - How to check the CertificateRequest
 - How to check the issuer state.
 . https://cert-manager.io/docs/faq/acme/[Troubleshooting Issuing ACME Certificates] such as Let's Encrypt.
+. Let's Encrypt does not provide support via email. Support questions are answered in their https://community.letsencrypt.org/[community forums].
 
 
 


### PR DESCRIPTION
Closes #191 

**Please note: PR #285 must be merged first before merging this PR**

## Description of Changes
I created two alerts:

- Triggered when calls to the TLS Provider (Let's Encrypt) have excessive errors or disconnections:
  - The expression used for this divides the total errors by the total requests, giving us the error rate in percentage. At the moment, it is triggered when the error rate is higher than 1%.
  - I created the appropriate unit tests to verify that it is working. In the test, there is an error rate of 2% which will be expected for the alert to be triggered.

- Triggered when calls to the TLS Provider (Let's Encrypt) have high latency.
  - The expression used for this divides the duration time in seconds by the total counted requests, giving us the latency rate. At the moment, it is triggered when the latency per request is greater than 0.5 seconds.
  - I created the unit test. There is a 0.6 seconds latency of which will be expected for the alert to be triggered.


I added documentation to each alert for SRE in case the alert is firing. This document provides more information on the alert and the prerequisites to solve the issue. Also, ideas on how it can be solved and how to troubleshoot it are also included.
