### PR TITLE
Add secret reconciler to manage migration annotations

### DIFF
--- a/cmd/kcp-glbc/main.go
+++ b/cmd/kcp-glbc/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler/deployment"
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler/dns"
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler/ingress"
+	"github.com/kuadrant/kcp-glbc/pkg/reconciler/secret"
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler/service"
 	"github.com/kuadrant/kcp-glbc/pkg/tls"
 	"github.com/kuadrant/kcp-glbc/pkg/util/env"
@@ -223,6 +224,12 @@ func main() {
 	})
 	exitOnError(err, "Failed to create Deployment controller")
 
+	secretController, err := secret.NewController(&secret.ControllerConfig{
+		SecretsClient:         kcpKubeClient,
+		SharedInformerFactory: kcpKubeInformerFactory,
+	})
+	exitOnError(err, "Failed to create Secret controller")
+
 	kcpKubeInformerFactory.Start(ctx.Done())
 	kcpKubeInformerFactory.WaitForCacheSync(ctx.Done())
 
@@ -241,6 +248,7 @@ func main() {
 
 	start(gCtx, serviceController)
 	start(gCtx, deploymentController)
+	start(gCtx, secretController)
 
 	g.Go(func() error {
 		// wait until the controllers have return before stopping serving metrics

--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -275,8 +275,7 @@ func TestMetrics(t *testing.T) {
 	// Continually gets the metrics and check no reconciliation occurred over a reasonable period of time.
 	test.Consistently(Metrics(test), 30*time.Second).Should(And(
 		HaveKey("glbc_controller_reconcile_total"),
-		WithTransform(Metric("glbc_controller_reconcile_total"), Equal(reconcileTotal),
-		),
+		WithTransform(Metric("glbc_controller_reconcile_total"), Equal(reconcileTotal)),
 	))
 
 	// Finally, delete the Ingress and assert the metrics to cover the entire lifecycle
@@ -284,25 +283,22 @@ func TestMetrics(t *testing.T) {
 		Delete(test.Ctx(), name, metav1.DeleteOptions{})).
 		To(Succeed())
 
-	// This test is currently broken due to the secret soft finalizers never getting removed
-	// https://github.com/Kuadrant/kcp-glbc/issues/309
-	//
 	// Only the TLS certificate Secret count and number of managed Ingresses should change
-	//test.Eventually(Metrics(test), TestTimeoutShort).Should(And(
-	//	HaveKey("glbc_tls_certificate_secret_count"),
-	//	WithTransform(Metric("glbc_tls_certificate_secret_count"), MatchFieldsP(IgnoreExtras,
-	//		Fields{
-	//			"Name":   EqualP("glbc_tls_certificate_secret_count"),
-	//			"Help":   EqualP("GLBC TLS certificate secret count"),
-	//			"Type":   EqualP(prometheus.MetricType_GAUGE),
-	//			"Metric": ContainElement(certificateSecretCount(issuer, 0)),
-	//		},
-	//	)),
-	//	HaveKey("glbc_ingress_managed_object_total"),
-	//	WithTransform(Metric("glbc_ingress_managed_object_total"), EqualP(
-	//		ingressManagedObjectTotal(0)),
-	//	),
-	//))
+	test.Eventually(Metrics(test), TestTimeoutShort).Should(And(
+		HaveKey("glbc_tls_certificate_secret_count"),
+		WithTransform(Metric("glbc_tls_certificate_secret_count"), MatchFieldsP(IgnoreExtras,
+			Fields{
+				"Name":   EqualP("glbc_tls_certificate_secret_count"),
+				"Help":   EqualP("GLBC TLS certificate secret count"),
+				"Type":   EqualP(prometheus.MetricType_GAUGE),
+				"Metric": ContainElement(certificateSecretCount(issuer, 0)),
+			},
+		)),
+		HaveKey("glbc_ingress_managed_object_total"),
+		WithTransform(Metric("glbc_ingress_managed_object_total"), EqualP(
+			ingressManagedObjectTotal(0)),
+		),
+	))
 
 	// The other metrics should not be updated
 	test.Consistently(Metrics(test), 15*time.Second).Should(And(

--- a/e2e/performance/ingress_test.go
+++ b/e2e/performance/ingress_test.go
@@ -75,7 +75,7 @@ func TestIngress(t *testing.T) {
 	wg := sync.WaitGroup{}
 	for i := 1; i <= ingressCount; i++ {
 		wg.Add(1)
-		go func (){
+		go func() {
 			defer wg.Done()
 			ingress := createTestIngress(test, namespace)
 			test.Expect(ingress).NotTo(BeNil())
@@ -130,7 +130,7 @@ func TestIngress(t *testing.T) {
 	test.Eventually(DNSRecords(test, namespace, "")).Should(HaveLen(0))
 	// ToDo Uncomment this as part of the KCP 0.6 upgrade.
 	// Currently a finalizer is left on teh secret that never gets removed preventing it from ever deleting
-	//test.Eventually(Secrets(test, namespace, "kuadrant.dev/hcg.managed=true")).Should(HaveLen(0))
+	test.Eventually(Secrets(test, namespace, "kuadrant.dev/hcg.managed=true")).Should(HaveLen(0))
 
 	// Finally, delete the test deployment and service resources
 	test.Expect(test.Client().Core().CoreV1().Services(namespace.Name).

--- a/pkg/reconciler/secret/controller.go
+++ b/pkg/reconciler/secret/controller.go
@@ -1,0 +1,81 @@
+package secret
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	"github.com/kuadrant/kcp-glbc/pkg/reconciler"
+)
+
+const controllerName = "kcp-glbc-secret"
+
+// NewController returns a new Controller which reconciles Secrets.
+func NewController(config *ControllerConfig) (*Controller, error) {
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName)
+	c := &Controller{
+		Controller:            reconciler.NewController(controllerName, queue),
+		coreClient:            config.SecretsClient,
+		sharedInformerFactory: config.SharedInformerFactory,
+	}
+	c.Process = c.process
+
+	c.sharedInformerFactory.Core().V1().Secrets().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.Enqueue(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.Enqueue(obj) },
+		DeleteFunc: func(obj interface{}) { c.Enqueue(obj) },
+	})
+
+	c.indexer = c.sharedInformerFactory.Core().V1().Secrets().Informer().GetIndexer()
+	c.secretLister = c.sharedInformerFactory.Core().V1().Secrets().Lister()
+
+	return c, nil
+}
+
+type ControllerConfig struct {
+	SecretsClient         kubernetes.ClusterInterface
+	SharedInformerFactory informers.SharedInformerFactory
+}
+
+type Controller struct {
+	*reconciler.Controller
+	sharedInformerFactory informers.SharedInformerFactory
+	coreClient            kubernetes.ClusterInterface
+	indexer               cache.Indexer
+	secretLister          corev1listers.SecretLister
+}
+
+func (c *Controller) process(ctx context.Context, key string) error {
+	object, exists, err := c.indexer.GetByKey(key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		c.Logger.Info("Secret was deleted", "key", key)
+		return nil
+	}
+
+	current := object.(*corev1.Secret)
+	target := current.DeepCopy()
+
+	if err = c.reconcile(ctx, target); err != nil {
+		return err
+	}
+
+	if !equality.Semantic.DeepEqual(target, current) {
+		_, err := c.coreClient.Cluster(logicalcluster.From(target)).CoreV1().Secrets(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
+		return err
+	}
+
+	return nil
+}

--- a/pkg/reconciler/secret/secret.go
+++ b/pkg/reconciler/secret/secret.go
@@ -1,0 +1,24 @@
+package secret
+
+import (
+	"context"
+	"strings"
+
+	"github.com/kuadrant/kcp-glbc/pkg/util/metadata"
+	"github.com/kuadrant/kcp-glbc/pkg/util/workloadMigration"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (c *Controller) reconcile(ctx context.Context, secret *corev1.Secret) error {
+	workloadMigration.Process(secret, c.Queue, c.Logger)
+	if secret.DeletionTimestamp != nil && !secret.DeletionTimestamp.IsZero() {
+		//in 0.5.0 these are never cleaned up properly
+		for _, f := range secret.Finalizers {
+			if strings.Contains(f, workloadMigration.SyncerFinalizer) {
+				metadata.RemoveFinalizer(secret, f)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #309 


## Description of Changes
<!-- Use this section to detail the changes. Remove if not needed -->
* Add a new reconciler for secrets to manage migration annotations


## Remaining Work 
<!-- Remove if not needed -->
- [x] Resolve error `2022-08-09T12:09:56.307+0100 ERROR cache/reflector.go:222 k8s.io/client-go@v0.0.0-20220524063253-5bb0eeecf2cf/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: the server could not find the requested resource (get secrets)`
- [ ] Consider refactor of deployment, service & secret reconcilers to use a generic reconciler to manage migration annotations. Some work was done in this direction (see https://github.com/david-martin/kcp-glbc/commit/214ee685f15911e2ac6557dd2c4bb861231a3dc3), but put on hold pending a better understanding of using a dynamic client in the kcp-dev fork of client go i.e. https://github.com/kcp-dev/apimachinery/pull/30

## Release and Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. Remove if not needed -->
* Test with the migration sample.sh

