### PR TITLE
Add Endpoints validation to DNS Record

### DIFF
--- a/config/crd/bases/kuadrant.dev_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.dev_dnsrecords.yaml
@@ -80,7 +80,10 @@ spec:
                         type: string
                       type: array
                   type: object
+                minItems: 1
                 type: array
+            required:
+            - endpoints
             type: object
           status:
             description: status is the most recently observed status of the dnsRecord.

--- a/pkg/apis/kuadrant/v1/types.go
+++ b/pkg/apis/kuadrant/v1/types.go
@@ -78,7 +78,10 @@ type Endpoint struct {
 
 // DNSRecordSpec contains the details of a DNS record.
 type DNSRecordSpec struct {
-	Endpoints []*Endpoint `json:"endpoints,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
+	// +required
+	Endpoints []*Endpoint `json:"endpoints"`
 }
 
 // DNSRecordStatus is the most recently observed status of each record.

--- a/utils/kcp-contrib/apiresourceschema.yaml
+++ b/utils/kcp-contrib/apiresourceschema.yaml
@@ -78,7 +78,10 @@ spec:
                       type: string
                     type: array
                 type: object
+              minItems: 1
               type: array
+          required:
+          - endpoints
           type: object
         status:
           description: status is the most recently observed status of the dnsRecord.


### PR DESCRIPTION
Closes #315 

## Description of Changes
DNS Records were attempted to be created with no endpoints. Adds validations to the DNSRecord CRD to check that endpoints are not nil and has at minimum 1 item.