### PR TITLE
Check on startup if TLS issuer exists

### DIFF
--- a/cmd/kcp-glbc/main.go
+++ b/cmd/kcp-glbc/main.go
@@ -182,7 +182,7 @@ func main() {
 		ingress.InitMetrics(certProvider)
 
 		_, err := certProvider.IssuerExists(ctx)
-		exitOnError(err, "Failed as cert provider does not exist")
+		exitOnError(err, "Failed cert provider issuer check")
 
 	}
 

--- a/cmd/kcp-glbc/main.go
+++ b/cmd/kcp-glbc/main.go
@@ -181,6 +181,9 @@ func main() {
 
 		ingress.InitMetrics(certProvider)
 
+		err = certProvider.Initialize(ctx)
+		exitOnError(err, "Failed to initialize cert provider")
+
 	}
 
 	glbcKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Minute, informers.WithNamespace(namespace))

--- a/cmd/kcp-glbc/main.go
+++ b/cmd/kcp-glbc/main.go
@@ -181,10 +181,9 @@ func main() {
 
 		ingress.InitMetrics(certProvider)
 
-		check, err := certProvider.IssuerExists(ctx)
-		if check == false {
-			exitOnError(err, "Failed as cert provider does not exist")
-		}
+		_, err := certProvider.IssuerExists(ctx)
+		exitOnError(err, "Failed as cert provider does not exist")
+
 	}
 
 	glbcKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Minute, informers.WithNamespace(namespace))

--- a/cmd/kcp-glbc/main.go
+++ b/cmd/kcp-glbc/main.go
@@ -181,9 +181,10 @@ func main() {
 
 		ingress.InitMetrics(certProvider)
 
-		err = certProvider.Initialize(ctx)
-		exitOnError(err, "Failed to initialize cert provider")
-
+		check, err := certProvider.IssuerExists(ctx)
+		if check == false {
+			exitOnError(err, "Failed as cert provider does not exist")
+		}
 	}
 
 	glbcKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Minute, informers.WithNamespace(namespace))

--- a/pkg/tls/cert_manager.go
+++ b/pkg/tls/cert_manager.go
@@ -105,9 +105,6 @@ func (cm *certManager) Domains() []string {
 func (cm *certManager) IssuerExists(ctx context.Context) (bool, error) {
 	_, err := cm.certClient.CertmanagerV1().Issuers(cm.certificateNS).Get(ctx, cm.IssuerID(), metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("Issuer %s not found", cm.IssuerID())
-		}
 		return false, err
 	}
 	return true, nil

--- a/pkg/tls/cert_manager.go
+++ b/pkg/tls/cert_manager.go
@@ -102,6 +102,17 @@ func (cm *certManager) Domains() []string {
 	return cm.validDomains
 }
 
+func (cm *certManager) Initialize(ctx context.Context) error {
+	_, err := cm.certClient.CertmanagerV1().Issuers(cm.certificateNS).Get(ctx, cm.IssuerID(), metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("Issuer %s not found", cm.IssuerID())
+		}
+		return err
+	}
+	return nil
+}
+
 func (cm *certManager) GetCertificateSecret(ctx context.Context, request CertificateRequest) (*corev1.Secret, error) {
 	c, err := cm.certClient.CertmanagerV1().Certificates(cm.certificateNS).Get(ctx, request.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/tls/cert_manager.go
+++ b/pkg/tls/cert_manager.go
@@ -102,15 +102,15 @@ func (cm *certManager) Domains() []string {
 	return cm.validDomains
 }
 
-func (cm *certManager) Initialize(ctx context.Context) error {
+func (cm *certManager) IssuerExists(ctx context.Context) (bool, error) {
 	_, err := cm.certClient.CertmanagerV1().Issuers(cm.certificateNS).Get(ctx, cm.IssuerID(), metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("Issuer %s not found", cm.IssuerID())
+			return false, fmt.Errorf("Issuer %s not found", cm.IssuerID())
 		}
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 func (cm *certManager) GetCertificateSecret(ctx context.Context, request CertificateRequest) (*corev1.Secret, error) {

--- a/pkg/tls/types.go
+++ b/pkg/tls/types.go
@@ -32,7 +32,7 @@ type Provider interface {
 	GetCertificateSecret(ctx context.Context, cr CertificateRequest) (*v1.Secret, error)
 	GetCertificate(ctx context.Context, cr CertificateRequest) (*certman.Certificate, error)
 	GetCertificateStatus(ctx context.Context, certReq CertificateRequest) (CertStatus, error)
-	Initialize(ctx context.Context) error
+	IssuerExists(ctx context.Context) (bool, error)
 }
 
 type CertificateRequest struct {

--- a/pkg/tls/types.go
+++ b/pkg/tls/types.go
@@ -32,6 +32,7 @@ type Provider interface {
 	GetCertificateSecret(ctx context.Context, cr CertificateRequest) (*v1.Secret, error)
 	GetCertificate(ctx context.Context, cr CertificateRequest) (*certman.Certificate, error)
 	GetCertificateStatus(ctx context.Context, certReq CertificateRequest) (CertStatus, error)
+	Initialize(ctx context.Context) error
 }
 
 type CertificateRequest struct {


### PR DESCRIPTION
Closes #297 


## Description of Changes
* Perform check to TLS Issuer - Controller fails to start if the TLS issuer does not exist.

   What is there now works. But, there might be a better way of doing this startup check.
