### PR TITLE
Cert issuer generates resources only

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -203,7 +203,8 @@ jobs:
 
           echo "Create the default glbc-ca issuer"
           KUBECONFIG=.kcp/admin.kubeconfig ./bin/kubectl-kcp workspace use "root:default:kcp-glbc"
-          go run ./utils/certman-issuer/ --glbc-kubeconfig .kcp/admin.kubeconfig --issuer-namespace=kcp-glbc
+          go run ./utils/certman-issuer/ --output-file ${TEMP_DIR}/issuer.yaml
+          KUBECONFIG=.kcp/admin.kubeconfig kubectl apply -n kcp-glbc -f ${TEMP_DIR}/issuer.yaml
 
           echo "Export GLBC CI Cluster Config Enviornment"
           export $(cat ./config/deploy/local/controller-config.env.ci | xargs)

--- a/utils/certman-issuer/ca.go
+++ b/utils/certman-issuer/ca.go
@@ -21,15 +21,13 @@ const (
 
 type CAIssuer struct {
 	tlsProvider string
-	namespace   string
 }
 
 var _ Issuer = &CAIssuer{}
 
-func NewCAIssuer(namespace string) *CAIssuer {
+func NewCAIssuer() *CAIssuer {
 	return &CAIssuer{
 		tlsProvider: CertProviderCA,
-		namespace:   namespace,
 	}
 }
 
@@ -80,8 +78,7 @@ func (issuer *CAIssuer) GetSecret() (*corev1.Secret, error) {
 func (issuer *CAIssuer) GetIssuer() *certman.Issuer {
 	return &certman.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: issuer.namespace,
-			Name:      issuer.tlsProvider,
+			Name: issuer.tlsProvider,
 		},
 		Spec: certman.IssuerSpec{
 			IssuerConfig: certman.IssuerConfig{

--- a/utils/certman-issuer/issuer.go
+++ b/utils/certman-issuer/issuer.go
@@ -1,27 +1,20 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
+	"os"
 
 	certman "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-	certmanclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
-	"github.com/kuadrant/kcp-glbc/pkg/util/env"
-	genericapiserver "k8s.io/apiserver/pkg/server"
-
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	"github.com/kuadrant/kcp-glbc/pkg/util/env"
 )
 
 const (
-	defaultCertificateNS string = "cert-manager"
-	caSecretName         string = "glbc-ca"
+	caSecretName string = "glbc-ca"
 )
 
 type Issuer interface {
@@ -30,13 +23,13 @@ type Issuer interface {
 	GetTLSProvider() string
 }
 
-func newIssuer(tlsProvider, awsRegion, namespace string) Issuer {
+func newIssuer(tlsProvider, awsRegion string) Issuer {
 	var issuer Issuer
 	switch tlsProvider {
 	case CertProviderCA:
-		issuer = NewCAIssuer(namespace)
+		issuer = NewCAIssuer()
 	case CertProviderLEStaging, CertProviderLEProd:
-		issuer = NewLetsEncryptIssuer(tlsProvider, awsRegion, namespace)
+		issuer = NewLetsEncryptIssuer(tlsProvider, awsRegion)
 	default:
 		log.Fatalln(fmt.Errorf("unsupported TLS certificate issuer: %s", issuer.GetTLSProvider()))
 	}
@@ -44,83 +37,40 @@ func newIssuer(tlsProvider, awsRegion, namespace string) Issuer {
 }
 
 func main() {
+	var outputFile string
+	var tlsProvider = ""
+	var awsRegion = ""
 
-	// Control cluster client options
-	var glbcKubeconfig string
-	var tlsProvider string = ""
-	var issuerNamespace string = ""
-	var awsRegion string = ""
-
-	flag.StringVar(&glbcKubeconfig, "glbc-kubeconfig", "", "Path to the physical GLBC cluster kubeconfig")
+	flag.StringVar(&outputFile, "output-file", "./tmp/issuer.yaml", "Where to output the files")
 	flag.StringVar(&tlsProvider, "glbc-tls-provider", env.GetEnvString("GLBC_TLS_PROVIDER", "glbc-ca"), "The TLS certificate issuer, one of [glbc-ca, le-staging, le-production]")
-	flag.StringVar(&issuerNamespace, "issuer-namespace", env.GetEnvString("NAMESPACE", defaultCertificateNS), "Define namespace where issuer will be created")
 	flag.StringVar(&awsRegion, "region", env.GetEnvString("AWS_REGION", "eu-central-1"), "the region we should target with AWS clients")
 	flag.Parse()
 
-	issuer := newIssuer(tlsProvider, awsRegion, issuerNamespace)
-	glbcClientConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: glbcKubeconfig},
-		&clientcmd.ConfigOverrides{}).ClientConfig()
+	printer := &printers.YAMLPrinter{}
+
+	//Create file and destination of file
+	issuerFile, err := os.Create(outputFile)
 	if err != nil {
-		log.Fatalln(fmt.Errorf("Failed to create K8S config %w", err))
+		log.Fatalln(fmt.Errorf("error creating issuer file : %v", err))
 	}
+	defer issuerFile.Close()
 
-	certManagerClient := certmanclient.NewForConfigOrDie(glbcClientConfig)
-
-	glbcKubeClient, err := kubernetes.NewForConfig(glbcClientConfig)
-	if err != nil {
-		log.Fatalln(fmt.Errorf("Failed to create K8S core client %w", err))
-	}
-
-	ctx := genericapiserver.SetupSignalContext()
-	if err := create(ctx, certManagerClient, glbcKubeClient, issuer); err != nil {
-		log.Fatalln(fmt.Errorf("failed to create issuer for : %s %w", tlsProvider, err))
-	}
-
-	log.Printf("Issuer %s successfully created in %s namespace ", tlsProvider, issuerNamespace)
-}
-
-func create(ctx context.Context, certManegerClient certmanclient.CertmanagerV1Interface, k8sClient kubernetes.Interface, issuerObject Issuer) error {
-
+	issuerObject := newIssuer(tlsProvider, awsRegion)
 	issuerSecret, err := issuerObject.GetSecret()
 	if err != nil {
-		return err
+		log.Fatalln(fmt.Errorf("failed to create issuer yaml file for : %s %w", tlsProvider, err))
 	}
+	issuerSecret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
 
 	issuer := issuerObject.GetIssuer()
+	issuer.SetGroupVersionKind(certman.SchemeGroupVersion.WithKind("Issuer"))
 
-	secretClientInterface := k8sClient.CoreV1().Secrets(issuer.GetNamespace())
-	secret, err := secretClientInterface.Get(ctx, issuerSecret.Name, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	} else if apierrors.IsNotFound(err) {
-		_, err = secretClientInterface.Create(ctx, issuerSecret, metav1.CreateOptions{})
-		if err != nil {
-			return err
-		}
-	} else {
-		issuerSecret.SetResourceVersion(secret.ResourceVersion)
-		_, err = secretClientInterface.Update(ctx, issuerSecret, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
+	if err := printer.PrintObj(issuer, issuerFile); err != nil {
+		log.Fatalln(fmt.Errorf("failed to generate issuer yaml : %s %w", tlsProvider, err))
+	}
+	if err := printer.PrintObj(issuerSecret, issuerFile); err != nil {
+		log.Fatalln(fmt.Errorf("failed to generate issuer secret yaml : %s %w", tlsProvider, err))
 	}
 
-	issuerClientInterface := certManegerClient.Issuers(issuer.GetNamespace())
-	issuerInstance, err := issuerClientInterface.Get(ctx, issuer.Name, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	} else if apierrors.IsNotFound(err) {
-		_, err = issuerClientInterface.Create(ctx, issuer, metav1.CreateOptions{})
-		if err != nil {
-			return err
-		}
-	} else {
-		issuer.SetResourceVersion(issuerInstance.GetResourceVersion())
-		_, err = issuerClientInterface.Update(ctx, issuer, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	log.Printf("Issuer %s yaml file successfully generated in %s directory ", tlsProvider, outputFile)
 }

--- a/utils/certman-issuer/le.go
+++ b/utils/certman-issuer/le.go
@@ -31,12 +31,11 @@ type LetsEncryptIssuer struct {
 	tlsProvider    string
 	server         string
 	providerRegion string
-	namespace      string
 }
 
 var _ Issuer = &LetsEncryptIssuer{}
 
-func NewLetsEncryptIssuer(tlsProvider, providerRegion, namespace string) *LetsEncryptIssuer {
+func NewLetsEncryptIssuer(tlsProvider, providerRegion string) *LetsEncryptIssuer {
 	server := leStagingAPI
 	if tlsProvider == string(CertProviderLEProd) {
 		server = leProdAPI
@@ -46,7 +45,6 @@ func NewLetsEncryptIssuer(tlsProvider, providerRegion, namespace string) *LetsEn
 		tlsProvider:    tlsProvider,
 		server:         server,
 		providerRegion: providerRegion,
-		namespace:      namespace,
 	}
 }
 
@@ -79,8 +77,7 @@ func (issuer *LetsEncryptIssuer) GetSecret() (*corev1.Secret, error) {
 func (issuer *LetsEncryptIssuer) GetIssuer() *certman.Issuer {
 	return &certman.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: issuer.namespace,
-			Name:      issuer.tlsProvider,
+			Name: issuer.tlsProvider,
 		},
 		Spec: certman.IssuerSpec{
 			IssuerConfig: certman.IssuerConfig{

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -152,8 +152,8 @@ deploy_glbc() {
   create_ns ${GLBC_NAMESPACE}
 
   echo "Creating issuer"
-  #ToDo This shouldn't be forcing us to set a value for the KUBECONFIG env var
-  go run ${DEPLOY_SCRIPT_DIR}/certman-issuer/ --glbc-kubeconfig ${KUBECONFIG} --issuer-namespace ${GLBC_NAMESPACE}
+  go run ${DEPLOY_SCRIPT_DIR}/certman-issuer/ --output-file ${GLBC_KUSTOMIZATION}/issuer.yaml
+  kubectl apply -n ${GLBC_NAMESPACE} -f ${GLBC_KUSTOMIZATION}/issuer.yaml
 
   echo "Deploying GLBC"
   ${KUSTOMIZE_BIN} build ${GLBC_KUSTOMIZATION} | kubectl apply -f -

--- a/utils/local-setup.sh
+++ b/utils/local-setup.sh
@@ -204,11 +204,12 @@ KUBECONFIG=${KUBECONFIG_KCP_ADMIN} OUTPUT_DIR=${TEMP_DIR} GLBC_USER_WORKLOAD_CLU
 #7. Miscellaneous local development specific steps
 KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${KUBECTL_KCP_BIN} workspace use "${ORG_WORKSPACE}:kcp-glbc"
 
-# Create the kcp-glbc namepsace, kcp-glbc-controller-manager service account and generate a kubeconfig for access
+# Create the kcp-glbc namespace, kcp-glbc-controller-manager service account and generate a kubeconfig for access
 KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${SCRIPT_DIR}/create_glbc_kubeconfig.sh -o ${KUBECONFIG_KCP_GLBC}
 
 # Create the default glbc-ca issuer
-go run ${SCRIPT_DIR}/certman-issuer/ --glbc-kubeconfig ${KUBECONFIG_KCP_ADMIN} --issuer-namespace=kcp-glbc
+go run ${SCRIPT_DIR}/certman-issuer/ --output-file ${TEMP_DIR}/issuer.yaml
+kubectl --kubeconfig=${KUBECONFIG_KCP_ADMIN} apply -n kcp-glbc -f ${TEMP_DIR}/issuer.yaml
 
 #8. Switch to user workspace
 KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${KUBECTL_KCP_BIN} workspace use "${ORG_WORKSPACE}:kcp-glbc-user"


### PR DESCRIPTION
Closes #304 


## Description of Changes
* Issuer script will only generate resources and specify an output directory for the yaml file.
* Issuer resources outputted in a single YAML file. We have an Issuer and a Secret kind.
* Updated local-setup and deploy scripts to make use and apply issuer.yaml file.
* Removed issuer namespace from metadata.