### PR TITLE
Fix lint errors

### DIFF
--- a/pkg/reconciler/dns/dns_record.go
+++ b/pkg/reconciler/dns/dns_record.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilclock "k8s.io/utils/clock"
 
 	"github.com/kcp-dev/logicalcluster/v2"
 


### PR DESCRIPTION
## Description of Changes

Fix lint errors:
* SA1019: utilclock.Clock is deprecated: Use k8s.io/utils/clock.WithTickerAndDelayedExecution instead. (staticcheck)

