### PR TITLE
prevent dns record from being created until after certificate ready

### DIFF
--- a/e2e/ingress_test.go
+++ b/e2e/ingress_test.go
@@ -143,6 +143,8 @@ func TestIngress(t *testing.T) {
 
 	// Check a DNSRecord for the Ingress is created with the expected Spec
 	test.Eventually(DNSRecord(test, namespace, name)).Should(And(
+		// ensure the ingress certificate is marked as ready when the DNSrecord is created
+		WithTransform(DNSRecordToIngressCertReady(test, namespace, name), Equal("ready")),
 		WithTransform(DNSRecordEndpoints, HaveLen(1)),
 		WithTransform(DNSRecordEndpoints, ContainElement(MatchFieldsP(IgnoreExtras,
 			Fields{

--- a/e2e/support/certificate.go
+++ b/e2e/support/certificate.go
@@ -21,7 +21,10 @@ import (
 	"encoding/pem"
 	"errors"
 
+	certman "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func CertificateFrom(secret *corev1.Secret) (*x509.Certificate, error) {
@@ -35,4 +38,21 @@ func CertificateFrom(secret *corev1.Secret) (*x509.Certificate, error) {
 		return nil, err
 	}
 	return cert, err
+}
+
+func GetCertificate(t Test, namespace, name string) *certman.Certificate {
+	t.T().Helper()
+	return TLSCertificate(t, namespace, name)(t)
+}
+
+func TLSCertificate(t Test, namespace, name string) func(g gomega.Gomega) *certman.Certificate {
+	return func(g gomega.Gomega) *certman.Certificate {
+		cert, err := t.Client().Certs().CertmanagerV1().Certificates(namespace).Get(t.Ctx(), name, v1.GetOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		return cert
+	}
+}
+
+func TLSCertificateSpec(cert *certman.Certificate) certman.CertificateSpec {
+	return cert.Spec
 }

--- a/e2e/support/client.go
+++ b/e2e/support/client.go
@@ -23,6 +23,7 @@ import (
 
 	kcp "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 
+	certmanclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	kuadrantv1 "github.com/kuadrant/kcp-glbc/pkg/client/kuadrant/clientset/versioned"
 )
 
@@ -30,6 +31,7 @@ type Client interface {
 	Core() kubernetes.ClusterInterface
 	Kcp() kcp.ClusterInterface
 	Kuadrant() kuadrantv1.ClusterInterface
+	Certs() certmanclient.Interface
 	GetConfig() *rest.Config
 }
 
@@ -37,7 +39,12 @@ type client struct {
 	core     kubernetes.ClusterInterface
 	kcp      kcp.ClusterInterface
 	kuadrant kuadrantv1.ClusterInterface
+	certs    certmanclient.Interface
 	config   *rest.Config
+}
+
+func (c *client) Certs() certmanclient.Interface {
+	return c.certs
 }
 
 func (c *client) Core() kubernetes.ClusterInterface {
@@ -81,10 +88,16 @@ func newTestClient() (Client, error) {
 		return nil, err
 	}
 
+	certClient, err := certmanclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	return &client{
 		core:     kubeClient,
 		kcp:      kcpClient,
 		kuadrant: kuandrantClient,
+		certs:    certClient,
 		config:   cfg,
 	}, nil
 }

--- a/e2e/support/dns.go
+++ b/e2e/support/dns.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
+	"github.com/kuadrant/kcp-glbc/pkg/access"
 	kuadrantv1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
 	"github.com/kuadrant/kcp-glbc/pkg/net"
 )
@@ -79,6 +80,13 @@ func DNSRecordCondition(zoneID, condition string) func(record *kuadrantv1.DNSRec
 			return nil
 		}
 		return nil
+	}
+}
+
+func DNSRecordToIngressCertReady(t Test, namespace *corev1.Namespace, name string) func(dnsrecord *kuadrantv1.DNSRecord) string {
+	return func(dnsrecord *kuadrantv1.DNSRecord) string {
+		ing := GetIngress(t, namespace, dnsrecord.Name)
+		return ing.Annotations[access.ANNOTATION_CERTIFICATE_STATE]
 	}
 }
 

--- a/e2e/support/ingress.go
+++ b/e2e/support/ingress.go
@@ -25,11 +25,10 @@ import (
 	"github.com/kuadrant/kcp-glbc/pkg/access"
 	"github.com/kuadrant/kcp-glbc/pkg/util/workloadMigration"
 
+	"github.com/kcp-dev/logicalcluster/v2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 func GetIngress(t Test, namespace *corev1.Namespace, name string) *networkingv1.Ingress {

--- a/pkg/reconciler/ingress/ingress_reconciler.go
+++ b/pkg/reconciler/ingress/ingress_reconciler.go
@@ -64,10 +64,10 @@ func (c *Controller) reconcile(ctx context.Context, ingress access.Accessor) err
 		},
 	}
 	var errs []error
-
 	for _, r := range reconcilers {
 		status, err := r.Reconcile(ctx, ingress)
 		if err != nil {
+			c.Logger.Error(err, "reconciler error: ", ingress)
 			errs = append(errs, err)
 		}
 		if status == access.ReconcileStatusStop {
@@ -77,6 +77,7 @@ func (c *Controller) reconcile(ctx context.Context, ingress access.Accessor) err
 
 	if len(errs) == 0 {
 		if ingress.GetDeletionTimestamp() != nil && !ingress.GetDeletionTimestamp().IsZero() {
+			c.Logger.Info("reconcile ingress deleted ", "ingress", ingress)
 			metadata.RemoveFinalizer(ingress, cascadeCleanupFinalizer)
 			c.hostsWatcher.StopWatching(objectKey(ingress), "")
 			//in 0.5.0 these are never cleaned up properly

--- a/pkg/tls/cert_manager.go
+++ b/pkg/tls/cert_manager.go
@@ -72,9 +72,9 @@ type CertManagerConfig struct {
 	CertProvider CertProvider
 	LEConfig     *LEConfig
 	Region       string
-	// client targeting the control cluster
+	// client targeting the glbc workspace cluster
 	K8sClient kubernetes.Interface
-	// namespace in the control cluster where we create certificates
+	// namespace in the control workspace where we create certificates
 	CertificateNS string
 	// set of domains we allow certs to be created for
 	ValidDomains []string

--- a/samples/echo-service/echo.yaml
+++ b/samples/echo-service/echo.yaml
@@ -49,3 +49,8 @@ spec:
                 name: echo
                 port:
                   number: 80
+  tls:
+  - hosts:
+      - host.whatever.com
+    secretName: testsecret-tls
+                    


### PR DESCRIPTION
Closes #310 


## Description of Changes
stop reconciliation until the certificate is marked as ready. This means the DNS record will only be added once the certificate is ready. If there is no DNSRecord then traffic cannot access the Ingress.


## Release and Testing
There is a e2e test that checks the certificate is ready. 

Also you can watch it via kubectly 

```
k get ingress -A -w  -o jsonpath='{.metadata.annotations.kuadrant\.dev/certificate-status}'

```

```
 k get DNSRecord -A -w

```

```
 kubectl apply -f samples/echo-service/echo.yaml

```

You will see the status of the certificate always moves to ready before the DNSRecord is created.
Another test is to scale down cert-manager and create an ingress. With the above watches you will see the cert is requested but no DNSRecord is created even if the ingress syncs and is given a load balancer status. Scale back up cert-manager and then the cert will move to ready and the DNSRecord created


## Dependencies
<!-- If this PR relies on other work or if it should be merged after a certain date, detail that here. Remove if not needed-->


