### PR TITLE
Check valid KUBECONFIG in local-setup

### DIFF
--- a/utils/local-setup-add-crc-cluster.sh
+++ b/utils/local-setup-add-crc-cluster.sh
@@ -55,6 +55,12 @@ KUBECTL_KCP_BIN="./bin/kubectl-kcp"
 : ${KCP_VERSION:="release-0.8"}
 KCP_SYNCER_IMAGE="ghcr.io/kcp-dev/kcp/syncer:${KCP_VERSION}"
 
+#Check that KUBECONFIG is not set to .kcp/admin.kubeconfig
+if [[ $KUBECONFIG == "${KUBECONFIG_KCP_ADMIN}" ]] ; then
+  echo "Can NOT add physical clusters (kind) if KUBECONFIG is set to .kcp/admin.kubeconfig"
+  exit 1 #this will trigger cleanup function
+fi
+
 crc start -p $PULL_SECRET
 
 cp ~/.crc/machines/crc/kubeconfig ${TEMP_DIR}/${CRC_KUBECONFIG}

--- a/utils/local-setup.sh
+++ b/utils/local-setup.sh
@@ -155,6 +155,12 @@ if ! [[ $clusterCount =~ "0" ]] ; then
   ${KIND_BIN} get clusters | grep ${KIND_CLUSTER_PREFIX} | xargs ${KIND_BIN} delete clusters
 fi
 
+#Check that KUBECONFIG is not set to .kcp/admin.kubeconfig
+if [[ $KUBECONFIG == "${KUBECONFIG_KCP_ADMIN}" ]] ; then
+  echo "Can NOT add physical clusters (kind) if KUBECONFIG is set to .kcp/admin.kubeconfig"
+  exit 1 #this will trigger cleanup function
+fi
+
 #1. Start KCP
 echo "Starting KCP, sending logs to ${KCP_LOG_FILE}"
 ${KCP_BIN} --v=9 start --run-controllers > ${KCP_LOG_FILE} 2>&1 &


### PR DESCRIPTION
Closes #395 


## Description of Changes
* Check to local-setup: if KUBECONFIG is set to `.kcp/admin.kubeconfig`, the script will exit and display a message.

Message: "Can NOT add physical clusters (kind) if KUBECONFIG is set to .kcp/admin.kubeconfig"


## Thoughts
* Wondering if that message is okay or should I simply say: "KUBECONFIG can not be set to .kcp/admin.kubeconfig".
* Check is placed after KCP is attempting to start so I could use the cleanup() exit function.