### PR TITLE
Remove redundant group field from APIBinding

### DIFF
--- a/config/apiexports/apibinding/glbc-apibinding.yaml
+++ b/config/apiexports/apibinding/glbc-apibinding.yaml
@@ -5,11 +5,9 @@ metadata:
   name: glbc
 spec:
   permissionClaims:
-  - group: ""
-    resource: secrets
+  - resource: secrets
     state: "Accepted"
-  - group: ""
-    identityHash: DUMMY_HASH
+  - identityHash: DUMMY_HASH
     resource: services
     state: "Accepted"
   - group: apps


### PR DESCRIPTION
## Description of Changes
<!-- Use this section to detail the changes. Remove if not needed -->
* The group field is redundant as it's an empty string. This causes a diff to always show up when comparing the APIBinding in a cluster with the version in the repo (e.g. what ArgoCD does to determine if an application is in sync)
