### PR TITLE
Patch local Grafana deployment version

### DIFF
--- a/config/observability/kubernetes/grafana_patch.yaml
+++ b/config/observability/kubernetes/grafana_patch.yaml
@@ -22,3 +22,12 @@
   value:
     name: glbc-slo-dashboard
     mountPath: /grafana-dashboard-definitions/0/glbc-slo-dashboard
+- op: replace
+  path: /metadata/labels/app.kubernetes.io~1version
+  value: 7.3.10
+- op: replace
+  path: /spec/template/metadata/labels/app.kubernetes.io~1version
+  value: 7.3.10
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: grafana/grafana:7.3.10


### PR DESCRIPTION
Closes #427 

Initially, I tried just changing the [kube-prometheus version](https://github.com/Kuadrant/kcp-glbc/blob/cc2b91dd873caac18da89a09307417cac0c66fb6/config/kube-prometheus/kustomization.yaml#L4), but I was getting a few errors and kube-state-metrics and other deployments were failing to become ready.

## Description of Changes
- I noticed there was already a grafana_patch.yaml file created. I used the same file to add the necessary patches to change the Grafana version to the same as our shared Grafana.
- I tested it locally and it seems to be working perfectly. Panels are working correctly. When creating new panels, the JSON model remains very similar from the shared Grafana dashboard which is good to avoid problems when merging any changes.